### PR TITLE
Ensuring numpy is imported when defining sim_func

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,7 @@ Next, add simulations to the problem as follows using the
 
 .. code-block:: python
 
+   import numpy as np
    from parmoo.searches import LatinHypercube
    from parmoo.surrogates import GaussRBF
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/wild/software/parmoo/parmoo/moop.py", line 1850, in solve
    sx = self.evaluateSimulation(x, i)
  File "/home/wild/software/parmoo/parmoo/moop.py", line 1181, in evaluateSimulation
    sx = np.asarray(self.sim_funcs[i](x))
  File "<stdin>", line 3, in sim_func
NameError: name 'np' is not defined