### PR TITLE
Feature/multistart

### DIFF
--- a/.github/workflows/parmoo-ci.yml
+++ b/.github/workflows/parmoo-ci.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python version
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "${{matrix.python-version}}"
 

--- a/.github/workflows/parmoo-ci.yml
+++ b/.github/workflows/parmoo-ci.yml
@@ -13,14 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.11"]
+        python-version: ["3.8", "3.11"]
 
     defaults:
       run:
         shell: bash
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python version
       uses: actions/setup-python@v4

--- a/.github/workflows/parmoo-ci.yml
+++ b/.github/workflows/parmoo-ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.10"]
+        python-version: ["3.8", "3.11"]
 
     defaults:
       run:

--- a/.github/workflows/parmoo-ci.yml
+++ b/.github/workflows/parmoo-ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.6", "3.11"]
 
     defaults:
       run:

--- a/parmoo/extras/libe.py
+++ b/parmoo/extras/libe.py
@@ -61,7 +61,6 @@ def parmoo_persis_gen(H, persis_info, gen_specs, libE_info):
     sim_count = 0
     # Iterate until the termination condition is reached
     while tag not in [STOP_TAG, PERSIS_STOP]:
-        print(f"----- Batch {k} -----")
         # Generate a batch by running one iteration
         x_out = moop.iterate(k)
         # Check for duplicates in simulation databases
@@ -143,7 +142,6 @@ def parmoo_persis_gen(H, persis_info, gen_specs, libE_info):
                 sim_count += new_count
         # Update the ParMOO databases
         moop.updateAll(k, batch)
-        print(f"------- Done. -------")
         k += 1
     # Return the results
     persis_info['moop'] = moop

--- a/parmoo/extras/libe.py
+++ b/parmoo/extras/libe.py
@@ -61,6 +61,7 @@ def parmoo_persis_gen(H, persis_info, gen_specs, libE_info):
     sim_count = 0
     # Iterate until the termination condition is reached
     while tag not in [STOP_TAG, PERSIS_STOP]:
+        print(f"----- Batch {k} -----")
         # Generate a batch by running one iteration
         x_out = moop.iterate(k)
         # Check for duplicates in simulation databases
@@ -142,6 +143,7 @@ def parmoo_persis_gen(H, persis_info, gen_specs, libE_info):
                 sim_count += new_count
         # Update the ParMOO databases
         moop.updateAll(k, batch)
+        print(f"------- Done. -------")
         k += 1
     # Return the results
     persis_info['moop'] = moop

--- a/parmoo/optimizers/lbfgsb.py
+++ b/parmoo/optimizers/lbfgsb.py
@@ -472,7 +472,7 @@ class TR_LBFGSB(SurrogateOptimizer):
             for i in range(self.restarts):
                 # Random starting point within bounds
                 x0 = (np.random.random_sample(self.n) *
-                      (bounds[:, 1] - bounds[:, 0]) - bounds[:, 0])
+                      (bounds[:, 1] - bounds[:, 0]) + bounds[:, 0])
                 res = optimize.minimize(scalar_f, x0, method='L-BFGS-B',
                                         jac=scalar_g, bounds=bounds,
                                         options={'maxiter': self.budget})

--- a/parmoo/optimizers/lbfgsb.py
+++ b/parmoo/optimizers/lbfgsb.py
@@ -531,7 +531,6 @@ class TR_LBFGSB(SurrogateOptimizer):
                                         options={'maxiter': self.budget})
                 if scalar_f(res['x']) < scalar_f(soln):
                     soln = res['x']
-            #print(np.max(np.abs(x[j, :] - soln)) / rad)
             # Append the found minima to the results list
             result.append(soln)
         return np.asarray(result)


### PR DESCRIPTION
Added multistarts to all solvers in ``parmoo/optimizers/lbfgsb.py``

 - For global LBFGSB solver, default number of starts is n+1
 - For local TR_LBFGSB solver, default number of starts is 2
 - For both, number of starts can be adjusted using optional 'opt_restarts' hyperparam
 - First start is always from the current minimum value for the current acquisition function, as seen in ParMOO current evaluation database (TR center for TR_LBFGSB)
 - Second start is found by evaluating the gradient of the surrogate at the first starting point, and following it to the boundary (typically a corner) of the bounding box
 - Third start and up are randomly sampled from the bounding box (or TR bounds)

