### PR TITLE
Hotfix/model improve

### DIFF
--- a/parmoo/surrogates/gaussian_proc.py
+++ b/parmoo/surrogates/gaussian_proc.py
@@ -320,16 +320,14 @@ class GaussRBF(SurrogateFunction):
             inds = np.argsort(dists)
             if dists[inds[self.n]] >= 1.5:
                 # Uniformly sample within the box [x - rad, x + rad].
-                rad = np.abs(x - self.x_vals[self.n])
-                xn = self.x_vals[self.n]
-                x_new = np.fmin(np.fmax(2.0 * np.random.random(self.n)
-                                        * rad[:] + (x - np.abs(xn)),
-                                        self.lb), self.ub)
+                rad = np.abs(x - self.x_vals[inds[self.n]])
+                x_new = np.fmin(np.fmax(2.0 * (np.random.random(self.n) - 0.5)
+                                        * rad[:] + x, self.lb), self.ub)
                 while any([np.all(np.abs(x_new - xj) < self.eps)
                            for xj in self.x_vals]):
-                    x_new = np.fmin(np.fmax(2.0 * np.random.random(self.n)
-                                            * rad[:] + (x - np.abs(xn)),
-                                            self.lb), self.ub)
+                    x_new = np.fmin(np.fmax(2.0 *
+                                            (np.random.random(self.n) - 0.5)
+                                            * rad[:] + x, self.lb), self.ub)
             else:
                 # If the n+1st nearest point is too close, use global_improv.
                 x_new[:] = self.lb[:] + np.random.random(self.n) \
@@ -721,17 +719,14 @@ class LocalGaussRBF(SurrogateFunction):
             inds = np.argsort(dists)
             if dists[inds[self.n_loc - 1]] > 1.5:
                 # Uniformly sample within B(x, dists[n_loc]).
-                xn = self.x_vals[self.n_loc - 1]
-                rad = np.abs(x - self.x_vals[self.n_loc - 1])
-                x_new = np.fmin(np.fmax(2.0 * np.random.random(self.n)
-                                        * rad[:] + (x - np.abs(xn)),
-                                        self.lb), self.ub)
+                rad = np.abs(x - self.x_vals[inds[self.n_loc - 1]])
+                x_new = np.fmin(np.fmax(2.0 * (np.random.random(self.n) - 0.5)
+                                        * rad[:] + x, self.lb), self.ub)
                 while any([np.all(np.abs(x_new - xj) < self.eps)
                            for xj in self.x_vals]):
-                    x_new = np.fmin(np.fmax(2.0 * rad[:] *
-                                            np.random.random(self.n) +
-                                            (x - np.abs(xn)),
-                                            self.lb), self.ub)
+                    x_new = np.fmin(np.fmax(2.0 *
+                                            (np.random.random(self.n) - 0.5)
+                                            * rad[:] + x, self.lb), self.ub)
             else:
                 # If the n_loc nearest point is too close, use global_improv
                 x_new[:] = self.lb[:] + np.random.random(self.n) \


### PR DESCRIPTION
Looks like an artifact from when I added support for custom embedders/extractors.  Wrong in so many ways that I'm not even 100% sure how the model improvements were being calculated previously, but now it should be correct.

When the model produces a value ``x`` that is already in the current dataset, we want to do a local model improvement by:
 - calculating the distance to the ``n_loc`` closest point to ``x`` in the current dataset (where ``n_loc`` is the number of local points needed to fit the model, by default, n+1)
 - calculating the 1d distance along each coordinate axis between ``x`` and the ``n_loc`` nearest point
 - if the max of those coordinate distances (i.e., the Manhattan distance) is greater than ``1.5 * eps`` then we will sample from that box until we discover a model improving iterate that is not already in the database
 - otherwise, we will generate a global sample