### PR TITLE
Better model-improvement steps

### DIFF
--- a/parmoo/moop.py
+++ b/parmoo/moop.py
@@ -550,7 +550,7 @@ class MOOP:
                    specifies the tolerance, i.e., the minimum spacing along
                    this dimension, before two design values are considered to
                    have equal values in this dimension. If not specified, the
-                   default value is 1.0e-8.
+                   default value is 1.0e-8 * (ub - lb).
                  * 'levels' (int or list): When des_type is 'categorical', this
                    specifies the number of levels for the variable (when int)
                    or the names of each valid category (when a list).
@@ -598,7 +598,12 @@ class MOOP:
                     else:
                         raise TypeError("args['des_tol'] must be a float")
                 else:
-                    des_tol = 1.0e-8
+                    if 'lb' in arg and 'ub' in arg and \
+                       isinstance(arg['lb'], float) and \
+                       isinstance(arg['ub'], float):
+                        des_tol = 1.0e-8 * max(arg['ub'] - arg['lb'], 1.0e-4)
+                    else:
+                        des_tol = 1.0e-8
                 if 'lb' in arg and 'ub' in arg:
                     if not (isinstance(arg['lb'], float) and
                             isinstance(arg['ub'], float)):


### PR DESCRIPTION
Fixed 2 issues:
 1.  Updated default value of ``des_tol`` hyperparameter to scale with ``ub - lb`` for all continuous variables
 2.  Model improvement regions are now given by an infty-norm box whose radius is determined by the infty-norm distance to ``n+1`` closest point, then scaled proportionally by the design tolerance in each dimension and inversely with sample standard deviation of those ``n+1`` points as calculated in each dimension

(1) is convenient since the design tolerance is applied in the rescaled space, and so the default value should be calculated accordingly.

(2) is important since we need to collect data that is orthogonal to the span of nearby samples whenever the algorithm begins to stall out.  On our test problems, this improves performance drastically, especially when structure-exploiting methods are applied.