### PR TITLE
fixed pandas issue creating duplicate keys

### DIFF
--- a/parmoo/viz/utilities.py
+++ b/parmoo/viz/utilities.py
@@ -107,14 +107,14 @@ def set_database(moop, db, points):
             for constraint in constraints:
                 indices = df[df[constraint] > 0].index
                 df.drop(indices, inplace=True)
-                df.reset_index(inplace=True)
+                df.reset_index(inplace=True, drop=True)
         elif points == 'constraint_violating':
             constraints = moop.getConstraintType().names
             df = database.copy(deep=True)
             for constraint in constraints:
                 indices = df[df[constraint] <= 0].index
                 df.drop(indices, inplace=True)
-                df.reset_index(inplace=True)
+                df.reset_index(inplace=True, drop=True)
         elif points == 'all':
             df = database
         elif points == 'none':


### PR DESCRIPTION
It looks like the latest pandas update broke something in the plotting library, but the fix was easy.

Just need to add the ``drop=True`` arg in the ``reset_indices`` function, to prevent creation of duplicate columns.

We will need to merge this into main for any of the plotting to work with the latest version of pandas.