### PR TITLE
Fixing categorical variable tolerances

### DIFF
--- a/parmoo/tests/unit_tests/test_moop_grads.py
+++ b/parmoo/tests/unit_tests/test_moop_grads.py
@@ -454,7 +454,9 @@ def test_MOOP_evaluateGradients_3():
     moop2.addAcquisition({'acquisition': FixedWeights})
     np.random.seed(0)
     moop2.solve(0)
+    np.random.seed(0)
     b1 = moop1.iterate(1)
+    np.random.seed(0)
     b2 = moop2.iterate(1)
     # Check that same solutions were found
     for x1, x2 in zip(b1, b2):


### PR DESCRIPTION
When the number of categorical variables is large, the ``improve(xi)`` function can sometimes generate duplicate values and the ``MOOP.iterate()`` method does not catch it.

This happens because categorical variables embedded with the default method can round slightly farther than their design tolerances predict when the dimension of the latent space gets large.

Downstream, this leads to un-even batch sizes which can affect parallel performance.

The easiest fix was to extract then re-embed variables before checking whether they are close "up to the design tolerance"

This is not prohibitively expensive since it only happens once per batch when the solver checks whether a decrease point was found.