### PR TITLE
updated parmoo structure to separate candidate generation from filtering

### DIFF
--- a/parmoo/extras/libe.py
+++ b/parmoo/extras/libe.py
@@ -65,12 +65,12 @@ def parmoo_persis_gen(H, persis_info, gen_specs, libE_info):
         # Generate a batch by running one iteration
         x_out = moop.iterate(k)
         # Check for duplicates in simulation databases
+        x_out = moop.filterBatch(x_out)
         xbatch = []
         ibatch = []
         for (xi, i) in x_out:
-            if moop.check_sim_db(xi, i) is None:
-                xbatch.append(xi)
-                ibatch.append(i)
+            xbatch.append(xi)
+            ibatch.append(i)
         # Get the batch size and allocate the H_o structured array
         b = len(xbatch)
         H_o = np.zeros(b, dtype=gen_specs['out'])
@@ -201,7 +201,7 @@ class libE_MOOP(MOOP):
      * ``libE_MOOP.update_sim_db(x, sx, s_name)``
      * ``libE_MOOP.evaluateSimulation(x, s_name)``
      * ``libE_MOOP.addData(x, sx)``
-     * ``libE_MOOP.iterate(k)``
+     * ``libE_MOOP.iterate(k, ib)``
      * ``libE_MOOP.updateAll(k, batch)``
 
     Finally, the following methods are used to retrieve data after the
@@ -583,19 +583,78 @@ class libE_MOOP(MOOP):
         self.moop.addData(x, sx)
         return
 
-    def iterate(self, k):
+    def iterate(self, k, ib=None):
         """ Perform an iteration of ParMOO's solver and generate candidates.
 
-        Generates a batch of suggested candidate points
-        (design point, simulation name) pairs, for the caller to evaluate
-        (externally if needed).
+        Generates a batch of suggested candidate points (design points)
+        or (candidate point, simulation name) pairs and returns to the
+        user for further processing. Note, this method may produce
+        duplicates.
 
         Args:
             k (int): The iteration counter (corresponding to MOOP.iteration).
 
+            ib (int, optional): The index of the acquisition function to
+                optimize and add to the current batch. Defaults to None,
+                which optimizes all acquisition functions and adds all
+                resulting candidates to the batch.
+
         Returns:
-            (list): A list of ordered pairs (tuples), specifying the
-            (design points, simulation name) that ParMOO suggests for
+            (list): A list of design points (numpy structured or 1D arrays) or
+            tuples (design points, simulation name) specifying the unfiltered
+            list of candidates that ParMOO recommends for true simulation
+            evaluations. Specifically:
+             * Each item or the first entry in tuple is either a numpy
+               structured array (when operating with named variables) or a
+               1D numpy.ndarray (in unnamed mode). When operating with
+               unnamed variables, the indices were assigned in the order
+               that the design variables were added to the MOOP using
+               `MOOP.addDesign(*args)`.
+             * If the item is a tuple, then the second entry in the tuple
+               is either the (str) name of the simulation to
+               evaluate (when operating with named variables) or the (int)
+               index of the simulation to evaluate (when operating in
+               unnamed mode). Note, in unnamed mode, simulation indices
+               were assigned in the order that they were added using
+               `MOOP.addSimulation(*args)`.
+
+        """
+
+        return self.moop.iterate(k, ib=ib)
+
+    def filterBatch(self, *xbatch):
+        """ Filter a batch produced by ParMOO's MOOP.iterate method.
+
+        Accepts one or more batches of candidate design points, produced
+        by the MOOP.iterate() method and checks both the batch and ParMOO's
+        database for redundancies. Any redundant points (up to the design
+        tolerance) are replaced by model improving points, using each
+        surrogate's Surrogate.improve() method.
+
+        Args:
+            *xbatch (list of numpy.ndarrays or tuples): The list of
+            unfiltered candidates returned by the MOOP.iterate() method.
+            A list of design points (numpy structured or 1D arrays) or
+            tuples (design points, simulation name) specifying the unfiltered
+            list of candidates that ParMOO recommends for true simulation
+            evaluations. Specifically:
+             * Each item or the first entry in tuple is either a numpy
+               structured array (when operating with named variables) or a
+               1D numpy.ndarray (in unnamed mode). When operating with
+               unnamed variables, the indices were assigned in the order
+               that the design variables were added to the MOOP using
+               `MOOP.addDesign(*args)`.
+             * If the item is a tuple, then the second entry in the tuple
+               is either the (str) name of the simulation to
+               evaluate (when operating with named variables) or the (int)
+               index of the simulation to evaluate (when operating in
+               unnamed mode). Note, in unnamed mode, simulation indices
+               were assigned in the order that they were added using
+               `MOOP.addSimulation(*args)`.
+
+        Returns:
+            (list): A filtered list of ordered pairs (tuples), specifying
+            the (design points, simulation name) that ParMOO suggests for
             evaluation. Specifically:
              * The first entry in each tuple is either a numpy structured
                array (when operating with named variables) or a 1D
@@ -612,7 +671,7 @@ class libE_MOOP(MOOP):
 
         """
 
-        return self.moop.iterate(k)
+        return self.moop.filterBatch(*xbatch)
 
     def updateAll(self, k, batch):
         """ Update all surrogates given a batch of freshly evaluated data.

--- a/parmoo/tests/unit_tests/test_moop.py
+++ b/parmoo/tests/unit_tests/test_moop.py
@@ -1053,10 +1053,12 @@ def test_MOOP_iterate():
         moop1.iterate(2.0)
     # Solve the MOOP with 1 iteration
     batch = moop1.iterate(0)
+    batch = moop1.filterBatch(batch)
     for (x, i) in batch:
         moop1.evaluateSimulation(x, i)
     moop1.updateAll(0, batch)
     batch = moop1.iterate(1)
+    batch = moop1.filterBatch(batch)
     for (x, i) in batch:
         moop1.evaluateSimulation(x, i)
     moop1.updateAll(1, batch)
@@ -1132,6 +1134,7 @@ def test_MOOP_iterate():
         moop2.evaluateSimulation(x, i)
     moop2.updateAll(0, batch)
     batch = moop2.iterate(1)
+    batch = moop2.filterBatch(batch)
     for (x, i) in batch:
         moop2.evaluateSimulation(x, i)
     moop2.updateAll(1, batch)
@@ -1213,6 +1216,7 @@ def test_MOOP_iterate():
         moop3.evaluateSimulation(x, i)
     moop3.updateAll(0, batch)
     batch = moop3.iterate(1)
+    batch = moop3.filterBatch(batch)
     for (x, i) in batch:
         moop3.evaluateSimulation(x, i)
     moop3.updateAll(1, batch)
@@ -1281,10 +1285,12 @@ def test_MOOP_iterate():
         moop4.addAcquisition({'acquisition': UniformWeights})
     # Do 2 iterates of the MOOP and extract the final database
     batch = moop4.iterate(0)
+    batch = moop4.filterBatch(batch)
     for (x, i) in batch:
         moop4.evaluateSimulation(x, i)
     moop4.updateAll(0, batch)
     batch = moop4.iterate(1)
+    batch = moop4.filterBatch(batch)
     for (x, i) in batch:
         moop4.evaluateSimulation(x, i)
     moop4.updateAll(1, batch)
@@ -1856,6 +1862,7 @@ def test_MOOP_save_load1():
     for i in range(3):
         moop1.addAcquisition({'acquisition': UniformWeights})
     batch = moop1.iterate(0)
+    batch = moop1.filterBatch(batch)
     for (xi, i) in batch:
         moop1.evaluateSimulation(xi, i)
     moop1.updateAll(0, batch)
@@ -2010,6 +2017,7 @@ def test_MOOP_checkpoint():
     moop1.setCheckpoint(True)
     # One iteration
     batch = moop1.iterate(0)
+    batch = moop1.filterBatch(batch)
     for (xi, i) in batch:
         moop1.evaluateSimulation(xi, i)
     moop1.updateAll(0, batch)


### PR DESCRIPTION
Structural improvements to ParMOO to allow for improved future parallelism.  Also further modularizes and cleans-up the ``MOOP`` and ``libE_MOOP`` classes.

 - Separate the ``MOOP.iterate`` method into 2 methods:  ``MOOP.iterate`` and ``MOOP.filterBatch``, which generate candidates via surrogate problem solution and filter the batch for duplicates/trigger model improvement, respectively
 - Allow for ``MOOP.iterate`` to be called with a subset of the total number of acquisitions, in order to generate candidates in parallel in a future release
 - Detected a serious bug that was introduced in released in v. 0.3.0, which causes candidate points to be filtered incorrectly.  Does not cause failures, but results in significantly decreased performance.  See line 2152 of ``moop.py``.  In a future release, a design point comparison utility function should be added to improve the legibility of this check.