### PR TITLE
Improved pattern search methods

### DIFF
--- a/parmoo/optimizers/__init__.py
+++ b/parmoo/optimizers/__init__.py
@@ -1,3 +1,3 @@
-from .gps_search import LocalGPS, GlobalGPS, QuickGPS
+from .gps_search import LocalGPS, GlobalGPS
 from .random_search import RandomSearch
 from .lbfgsb import LBFGSB, TR_LBFGSB

--- a/parmoo/optimizers/__init__.py
+++ b/parmoo/optimizers/__init__.py
@@ -1,3 +1,3 @@
-from .gps_search import LocalGPS, GlobalGPS
+from .gps_search import LocalGPS, GlobalGPS, QuickGPS
 from .random_search import RandomSearch
 from .lbfgsb import LBFGSB, TR_LBFGSB

--- a/parmoo/optimizers/gps_search.py
+++ b/parmoo/optimizers/gps_search.py
@@ -9,6 +9,7 @@ require objective, constraint, or surrogate gradients methods to be defined.
 
 The classes include:
  * ``LocalGPS`` -- Generalized Pattern Search (GPS) algorithm
+ * ``QuickGPS`` -- GPS plus some smoothing of polls to take fewer f evals
  * ``GlobalGPS`` -- global random search, followed by GPS
 
 """
@@ -226,11 +227,239 @@ class LocalGPS(SurrogateOptimizer):
         return np.asarray(result)
 
 
+class QuickGPS(SurrogateOptimizer):
+    """ Use Generalized Pattern Search (GPS) to identify local solutions.
+
+    Applies GPS to the surrogate problem, in order to identify design
+    points that are locally Pareto optimal, with respect to the surrogate
+    problem. Sorts poll directions by most recently used and attempts to
+    step in promising directions in late iterations.
+
+    """
+
+    # Slots for the QuickGPS class
+    __slots__ = ['n', 'lb', 'ub', 'acquisitions', 'budget', 'constraints',
+                 'objectives', 'simulations', 'gradients', 'resetObjectives',
+                 'penalty_func', 'sim_sd', 'restarts', 'momentum']
+
+    def __init__(self, o, lb, ub, hyperparams):
+        """ Constructor for the QuickGPS class.
+
+        Args:
+            o (int): The number of objectives.
+
+            lb (numpy.ndarray): A 1d array of lower bounds for the design
+                region. The number of design variables is inferred from the
+                dimension of lb.
+
+            ub (numpy.ndarray): A 1d array of upper bounds for the design
+                region. The dimension must match ub.
+
+            hyperparams (dict): A dictionary of hyperparameters for the
+                optimization procedure. It may contain the following:
+                 * opt_budget (int): The GPS iteration limit (default: 1000).
+                 * opt_restarts (int): Number of multisolve restarts per
+                   scalarization (default: n+1).
+
+        Returns:
+            SurrogateOptimizer: A new SurrogateOptimizer object.
+
+        """
+
+        # Check inputs
+        xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
+        self.n = lb.size
+        self.lb = lb
+        self.ub = ub
+        # Check that the contents of hyperparams is legal
+        if 'opt_restarts' in hyperparams:
+            if isinstance(hyperparams['opt_restarts'], int):
+                if hyperparams['opt_restarts'] < 1:
+                    raise ValueError("hyperparams['opt_restarts'] "
+                                     "must be positive")
+                else:
+                    self.restarts = hyperparams['opt_restarts']
+            else:
+                raise TypeError("hyperparams['opt_restarts'] "
+                                 "must be an integer")
+        else:
+            self.restarts = self.n + 1
+        # Check that the contents of hyperparams is legal
+        if 'opt_budget' in hyperparams:
+            if isinstance(hyperparams['opt_budget'], int):
+                if hyperparams['opt_budget'] < 1:
+                    raise ValueError("hyperparams['opt_budget'] "
+                                     "must be positive")
+                else:
+                    self.budget = hyperparams['opt_budget']
+            else:
+                raise TypeError("hyperparams['opt_budget'] "
+                                 "must be an integer")
+        else:
+            self.budget = 1000
+        # Check that the contents of hyperparams is legal
+        if 'opt_momentum' in hyperparams:
+            if isinstance(hyperparams['opt_momentum'], float):
+                if 0 <= hyperparams['opt_budget'] < 1:
+                    self.momentum = hyperparams['opt_momentum']
+                else:
+                    raise ValueError("hyperparams['opt_momentum'] "
+                                     "must be in [0, 1)")
+            else:
+                raise TypeError("hyperparams['opt_momentum'] "
+                                 "must be a float")
+        else:
+            self.momentum = 9e-1
+        self.acquisitions = []
+        return
+
+    @profile
+    def solve(self, x):
+        """ Solve the surrogate problem using generalized pattern search (GPS).
+
+        Args:
+            x (np.ndarray): A 2d array containing a list of feasible
+                design points used to warm start the search.
+
+        Returns:
+            np.ndarray: A 2d numpy.ndarray of potentially efficient design
+            points that were found by the GPS optimizer.
+
+        """
+
+        # Check that x is legal
+        if isinstance(x, np.ndarray):
+            if self.n != x.shape[1]:
+                raise ValueError("The columns of x must match n")
+            elif len(self.acquisitions) != x.shape[0]:
+                raise ValueError("The rows of x must match the number " +
+                                 "of acquisition functions")
+        else:
+            raise TypeError("x must be a numpy array")
+        # Initialize an empty list of results
+        result = []
+        # For each acqusisition function
+        for j, acquisition in enumerate(self.acquisitions):
+            # Create a new trust region
+            rad = self.resetObjectives(x[j, :])
+            mesh_size = np.zeros(self.n)
+            m_tmp = np.zeros(self.n)
+            lb_tmp = np.zeros(self.n)
+            ub_tmp = np.ones(self.n)
+            for i in range(self.n):
+                lb_tmp[i] = max(self.lb[i], x[j, i] - rad)
+                ub_tmp[i] = min(self.ub[i], x[j, i] + rad)
+            # Initialize temp arrays
+            f_min = np.zeros(self.restarts)
+            x_center = np.zeros(self.n)
+            x_min = np.zeros((self.restarts, self.n))
+            x_tmp = np.zeros(self.n)
+            # Loop over restarts
+            for kk in range(self.restarts):
+                # Reset the mesh dimensions
+                mesh_size[:] = 0.25 * (ub_tmp[:] - lb_tmp[:])
+                mesh = np.vstack((np.zeros((1,self.n)),
+                                  np.diag(ub_tmp[:] - lb_tmp[:]),
+                                  -np.diag(ub_tmp[:] - lb_tmp[:])))
+                # Evaluate the starting point
+                sx = np.asarray(self.simulations(x[j, :]))
+                if acquisition.useSD():
+                    sdx = np.asarray(self.sim_sd(x[j, :]))
+                else:
+                    sdx = np.zeros(sx.size)
+                if kk == 0:
+                    x_min[kk, :] = x[j, :]
+                else:
+                    x_min[kk, :] = (np.random.random_sample(self.n) *
+                                    (ub_tmp - lb_tmp) + lb_tmp)
+                fx = np.asarray(self.penalty_func(x_min[kk, :], sx))
+                f_min[kk] = acquisition.scalarize(fx.flatten(), x_min[kk, :],
+                                                  sx, sdx)
+                # Take n+1 iterations to start
+                for k in range(self.n+1):
+                    # Track whether or not there is improvement
+                    improve = False
+                    x_center[:] = x_min[kk, :]
+                    for i, mi in enumerate(mesh[1:, :]):
+                        # Evaluate x + mi
+                        x_tmp[:] = x_center[:] + mi[:] * mesh_size[:]
+                        if np.any(x_tmp > ub_tmp) or np.any(x_tmp < lb_tmp):
+                            f_tmp = np.inf
+                        else:
+                            sx = np.asarray(self.simulations(x_tmp))
+                            if acquisition.useSD():
+                                sdx = self.sim_sd(x_tmp)
+                            else:
+                                sdx = 0.0
+                            fx = self.penalty_func(x_tmp, sx)
+                            f_tmp = acquisition.scalarize(fx, x_tmp, sx, sdx)
+                        # Check for improvement
+                        if f_tmp + 1.0e-8 < f_min[kk]:
+                            f_min[kk] = f_tmp
+                            x_min[kk, :] = x_tmp[:]
+                            m_min = i + 1
+                            improve = True
+                    # If there was improvement, shuffle the directions
+                    if improve:
+                        m_tmp[:] = mesh[m_min, :]
+                        mesh[2:m_min, :] = mesh[1:m_min-1, :]
+                        mesh[1, :] = m_tmp[:]
+                    # If no improvement, decay the mesh down to the tolerance
+                    else:
+                        if np.any(mesh_size[:] < 2.0e-8):
+                            break
+                        else:
+                            mesh_size[:] = mesh_size[:] * 0.5
+                # Take the remaining iterations
+                for k in range(self.n+1, self.budget):
+                    # Track whether or not there is improvement
+                    improve = False
+                    x_center[:] = x_min[kk, :]
+                    for i, mi in enumerate(mesh[:, :]):
+                        # Evaluate x + mi
+                        x_tmp[:] = x_center[:] + np.rint(mi[:]) * mesh_size[:]
+                        if np.any(x_tmp > ub_tmp) or np.any(x_tmp < lb_tmp):
+                            f_tmp = np.inf
+                        else:
+                            sx = np.asarray(self.simulations(x_tmp))
+                            if acquisition.useSD():
+                                sdx = self.sim_sd(x_tmp)
+                            else:
+                                sdx = 0.0
+                            fx = self.penalty_func(x_tmp, sx)
+                            f_tmp = acquisition.scalarize(fx, x_tmp, sx, sdx)
+                        # Check for improvement
+                        if f_tmp + 1.0e-8 < f_min[kk]:
+                            f_min[kk] = f_tmp
+                            x_min[kk, :] = x_tmp[:]
+                            m_min = i
+                            improve = True
+                            break
+                    # If there was improvement, shuffle the directions
+                    if improve:
+                        mesh[0, :] = (mesh[0, :] * (1 - self.momentum) +
+                                      mesh[m_min, :] * self.momentum)
+                        if m_min > 0:
+                            m_tmp[:] = mesh[m_min, :]
+                            mesh[2:m_min, :] = mesh[1:m_min-1, :]
+                            mesh[1, :] = m_tmp[:]
+                    # If no improvement, decay the mesh down to the tolerance
+                    else:
+                        if np.any(mesh_size[:] < 2.0e-8):
+                            break
+                        else:
+                            mesh_size[:] = mesh_size[:] * 0.5
+            # Append the found minima to the results list
+            x_cand_ind = np.argmin(f_min)
+            result.append(x_min[x_cand_ind, :].copy())
+        return np.asarray(result)
+
+
 class GlobalGPS(SurrogateOptimizer):
     """ Use randomized search globally followed by GPS locally.
 
     Use ``RandomSearch`` to globally search the design space (search phase)
-    followed by ``LocalGPS`` to refine the potentially efficient solutions
+    followed by ``QuickGPS`` to refine the potentially efficient solutions
     (poll phase).
 
     """
@@ -341,8 +570,9 @@ class GlobalGPS(SurrogateOptimizer):
         gs_soln = gs.solve(x)
         gps_budget_loc = int(self.gps_budget / gs_soln.shape[0])
         # Do a local search to refine the global solution
-        ls = LocalGPS(self.n, self.lb, self.ub,
-                      {'opt_budget': gps_budget_loc})
+        ls = QuickGPS(self.n, self.lb, self.ub,
+                      {'opt_budget': gps_budget_loc,
+                       'opt_restarts': 1})
         ls.setObjective(self.objectives)
         ls.setSimulation(self.simulations, self.sim_sd)
         ls.setPenalty(self.penalty_func, self.gradients)

--- a/parmoo/optimizers/gps_search.py
+++ b/parmoo/optimizers/gps_search.py
@@ -361,6 +361,7 @@ class QuickGPS(SurrogateOptimizer):
                 mesh = np.vstack((np.zeros((1,self.n)),
                                   np.diag(ub_tmp[:] - lb_tmp[:]),
                                   -np.diag(ub_tmp[:] - lb_tmp[:])))
+                mesh_tol = max(1.0e-8, np.min((ub_tmp - lb_tmp) * 1.0e-4))
                 # Evaluate the starting point
                 sx = np.asarray(self.simulations(x[j, :]))
                 if acquisition.useSD():
@@ -383,7 +384,7 @@ class QuickGPS(SurrogateOptimizer):
                     for i, mi in enumerate(mesh[1:, :]):
                         # Evaluate x + mi
                         x_tmp[:] = x_center[:] + mi[:] * mesh_size[:]
-                        if np.any(x_tmp > ub_tmp) or np.any(x_tmp < lb_tmp):
+                        if np.any((x_tmp > ub_tmp) + (x_tmp < lb_tmp)):
                             f_tmp = np.inf
                         else:
                             sx = np.asarray(self.simulations(x_tmp))
@@ -406,7 +407,7 @@ class QuickGPS(SurrogateOptimizer):
                         mesh[1, :] = m_tmp[:]
                     # If no improvement, decay the mesh down to the tolerance
                     else:
-                        if np.any(mesh_size[:] < 2.0e-8):
+                        if np.any(mesh_size[:] < mesh_tol):
                             break
                         else:
                             mesh_size[:] = mesh_size[:] * 0.5
@@ -418,7 +419,7 @@ class QuickGPS(SurrogateOptimizer):
                     for i, mi in enumerate(mesh[:, :]):
                         # Evaluate x + mi
                         x_tmp[:] = x_center[:] + np.rint(mi[:]) * mesh_size[:]
-                        if np.any(x_tmp > ub_tmp) or np.any(x_tmp < lb_tmp):
+                        if np.any((x_tmp > ub_tmp) + (x_tmp < lb_tmp)):
                             f_tmp = np.inf
                         else:
                             sx = np.asarray(self.simulations(x_tmp))
@@ -445,7 +446,7 @@ class QuickGPS(SurrogateOptimizer):
                             mesh[1, :] = m_tmp[:]
                     # If no improvement, decay the mesh down to the tolerance
                     else:
-                        if np.any(mesh_size[:] < 2.0e-8):
+                        if np.any(mesh_size[:] < mesh_tol):
                             break
                         else:
                             mesh_size[:] = mesh_size[:] * 0.5

--- a/parmoo/optimizers/gps_search.py
+++ b/parmoo/optimizers/gps_search.py
@@ -63,7 +63,7 @@ class LocalGPS(SurrogateOptimizer):
         self.lb = lb
         self.ub = ub
         self.q_ind = 0
-        # Check that the contents of hyperparams is legal
+        # Check that the contents of hyperparams are legal
         if 'opt_restarts' in hyperparams:
             if isinstance(hyperparams['opt_restarts'], int):
                 if hyperparams['opt_restarts'] < 1:
@@ -76,7 +76,7 @@ class LocalGPS(SurrogateOptimizer):
                                  "must be an integer")
         else:
             self.restarts = self.n + 1
-        # Check that the contents of hyperparams is legal
+        # Check that the contents of hyperparams are legal
         if 'opt_budget' in hyperparams:
             if isinstance(hyperparams['opt_budget'], int):
                 if hyperparams['opt_budget'] < 1:
@@ -89,7 +89,7 @@ class LocalGPS(SurrogateOptimizer):
                                  "must be an integer")
         else:
             self.budget = 1000
-        # Check that the contents of hyperparams is legal
+        # Check that the contents of hyperparams are legal
         if 'opt_momentum' in hyperparams:
             if isinstance(hyperparams['opt_momentum'], float):
                 if 0 <= hyperparams['opt_momentum'] < 1:
@@ -221,7 +221,7 @@ class GlobalGPS(SurrogateOptimizer):
         self.o = o
         self.lb = lb
         self.ub = ub
-        # Check that the contents of hyperparams is legal
+        # Check that the contents of hyperparams are legal
         if 'opt_budget' in hyperparams:
             if isinstance(hyperparams['opt_budget'], int):
                 if hyperparams['opt_budget'] < 1:
@@ -234,7 +234,7 @@ class GlobalGPS(SurrogateOptimizer):
                                  "must be an integer")
         else:
             self.opt_budget = 1500
-        # Check that the contents of hyperparams is legal
+        # Check that the contents of hyperparams are legal
         if 'gps_budget' in hyperparams:
             if isinstance(hyperparams['gps_budget'], int):
                 if hyperparams['gps_budget'] < 1 or \
@@ -249,7 +249,7 @@ class GlobalGPS(SurrogateOptimizer):
                                  "must be an integer")
         else:
             self.gps_budget = int(2 * self.opt_budget / 3)
-        # Check that the contents of hyperparams is legal
+        # Check that the contents of hyperparams are legal
         if 'opt_momentum' in hyperparams:
             if isinstance(hyperparams['opt_momentum'], float):
                 if 0 <= hyperparams['opt_momentum'] < 1:

--- a/parmoo/optimizers/gps_search.py
+++ b/parmoo/optimizers/gps_search.py
@@ -9,7 +9,6 @@ require objective, constraint, or surrogate gradients methods to be defined.
 
 The classes include:
  * ``LocalGPS`` -- Generalized Pattern Search (GPS) algorithm
- * ``QuickGPS`` -- GPS plus some smoothing of polls to take fewer f evals
  * ``GlobalGPS`` -- global random search, followed by GPS
 
 """
@@ -24,14 +23,15 @@ class LocalGPS(SurrogateOptimizer):
 
     Applies GPS to the surrogate problem, in order to identify design
     points that are locally Pareto optimal, with respect to the surrogate
-    problem.
+    problem. Sorts poll directions by most recently used and attempts to
+    step in promising directions in late iterations.
 
     """
 
     # Slots for the LocalGPS class
     __slots__ = ['n', 'lb', 'ub', 'acquisitions', 'budget', 'constraints',
                  'objectives', 'simulations', 'gradients', 'resetObjectives',
-                 'penalty_func', 'sim_sd', 'restarts']
+                 'penalty_func', 'sim_sd', 'restarts', 'momentum', 'q_ind']
 
     def __init__(self, o, lb, ub, hyperparams):
         """ Constructor for the LocalGPS class.
@@ -62,215 +62,7 @@ class LocalGPS(SurrogateOptimizer):
         self.n = lb.size
         self.lb = lb
         self.ub = ub
-        # Check that the contents of hyperparams is legal
-        if 'opt_restarts' in hyperparams:
-            if isinstance(hyperparams['opt_restarts'], int):
-                if hyperparams['opt_restarts'] < 1:
-                    raise ValueError("hyperparams['opt_restarts'] "
-                                     "must be positive")
-                else:
-                    self.restarts = hyperparams['opt_restarts']
-            else:
-                raise TypeError("hyperparams['opt_restarts'] "
-                                 "must be an integer")
-        else:
-            self.restarts = self.n + 1
-        # Check that the contents of hyperparams is legal
-        if 'opt_budget' in hyperparams:
-            if isinstance(hyperparams['opt_budget'], int):
-                if hyperparams['opt_budget'] < 1:
-                    raise ValueError("hyperparams['opt_budget'] "
-                                     "must be positive")
-                else:
-                    self.budget = hyperparams['opt_budget']
-            else:
-                raise TypeError("hyperparams['opt_budget'] "
-                                 "must be an integer")
-        else:
-            self.budget = 1000
-        self.acquisitions = []
-        return
-
-    def solve(self, x):
-        """ Solve the surrogate problem using generalized pattern search (GPS).
-
-        Args:
-            x (np.ndarray): A 2d array containing a list of feasible
-                design points used to warm start the search.
-
-        Returns:
-            np.ndarray: A 2d numpy.ndarray of potentially efficient design
-            points that were found by the GPS optimizer.
-
-        """
-
-        # Check that x is legal
-        if isinstance(x, np.ndarray):
-            if self.n != x.shape[1]:
-                raise ValueError("The columns of x must match n")
-            elif len(self.acquisitions) != x.shape[0]:
-                raise ValueError("The rows of x must match the number " +
-                                 "of acquisition functions")
-        else:
-            raise TypeError("x must be a numpy array")
-        # Initialize an empty list of results
-        result = []
-        # For each acqusisition function
-        for j, acquisition in enumerate(self.acquisitions):
-            # Create a new trust region
-            rad = self.resetObjectives(x[j, :])
-            lb_tmp = np.zeros(self.n)
-            ub_tmp = np.ones(self.n)
-            for i in range(self.n):
-                lb_tmp[i] = max(self.lb[i], x[j, i] - rad)
-                ub_tmp[i] = min(self.ub[i], x[j, i] + rad)
-            # Initialize temp arrays
-            f_min = np.zeros(self.restarts)
-            x_big = np.zeros(self.n)
-            x_center = np.zeros(self.n)
-            x_min = np.zeros((self.restarts, self.n))
-            x_tmp = np.zeros(self.n)
-            # Loop over restarts
-            for kk in range(self.restarts):
-                # Reset the mesh dimensions
-                mesh = np.diag(ub_tmp[:] - lb_tmp[:] * 0.25)
-                # Evaluate the starting point
-                sx = np.asarray(self.simulations(x[j, :]))
-                if acquisition.useSD():
-                    sdx = np.asarray(self.sim_sd(x[j, :]))
-                else:
-                    sdx = np.zeros(sx.size)
-                if kk == 0:
-                    x_min[kk, :] = x[j, :]
-                else:
-                    x_min[kk, :] = (np.random.random_sample(self.n) *
-                                    (ub_tmp - lb_tmp) + lb_tmp)
-                fx = np.asarray(self.penalty_func(x_min[kk, :], sx))
-                f_min[kk] = acquisition.scalarize(fx.flatten(), x_min[kk, :],
-                                                  sx, sdx)
-                # Loop over the budget
-                for k in range(self.budget):
-                    # Track whether or not there is improvement
-                    improve = False
-                    # Build an extra accelerating descent step
-                    x_big[:] = 0.0
-                    f_center = f_min[kk]
-                    x_center[:] = x_min[kk, :]
-                    for i in range(self.n):
-                        # Evaluate x + mesh[:, i]
-                        x_tmp = x_center[:] + mesh[:, i]
-                        if any(x_tmp > ub_tmp):
-                            f_plus = np.inf
-                        else:
-                            sx = np.asarray(self.simulations(x_tmp))
-                            if acquisition.useSD():
-                                sdx = self.sim_sd(x_tmp)
-                            else:
-                                sdx = 0.0
-                            fx = self.penalty_func(x_tmp, sx)
-                            f_plus = acquisition.scalarize(fx, x_tmp, sx, sdx)
-                        # Check for improvement
-                        if f_plus + 1.0e-8 < f_center:
-                            if f_plus / f_center < 0.999:
-                                x_big[i] = mesh[i, i]
-                            if f_plus + 1.0e-8 < f_min[kk]:
-                                f_min[kk] = f_plus
-                                x_min[kk, :] = x_tmp
-                                improve = True
-                        # Evaluate x - mesh[:, i]
-                        x_tmp = x_center[:] - mesh[:, i]
-                        if any(x_tmp < lb_tmp):
-                            f_minus = np.inf
-                        else:
-                            sx = np.asarray(self.simulations(x_tmp))
-                            if acquisition.useSD():
-                                sdx = self.sim_sd(x_tmp)
-                            else:
-                                sdx = 0.0
-                            fx = self.penalty_func(x_tmp, sx)
-                            f_minus = acquisition.scalarize(fx, x_tmp, sx, sdx)
-                        # Check for improvement
-                        if f_minus + 1.0e-8 < f_center:
-                            if f_minus / f_center < 0.999 and f_minus < f_plus:
-                                x_big[i] = -mesh[i, i]
-                            if f_minus + 1.0e-8 < f_min[kk]:
-                                f_min[kk] = f_minus
-                                x_min[kk, :] = x_tmp
-                                improve = True
-                    # If improvement found, try taking a big step
-                    if improve:
-                        if np.count_nonzero(x_big) > 1:
-                            x_tmp = x_center[:] + x_big[:]
-                            if any(x_tmp > ub_tmp) or any(x_tmp < lb_tmp):
-                                f_tmp = np.inf
-                            else:
-                                sx = np.asarray(self.simulations(x_tmp))
-                                if acquisition.useSD():
-                                    sdx = self.sim_sd(x_tmp)
-                                else:
-                                    sdx = 0.0
-                                fx = self.penalty_func(x_tmp, sx)
-                                f_tmp = acquisition.scalarize(fx, x_tmp,
-                                                              sx, sdx)
-                            if f_tmp + 1.0e-8 < f_min[kk]:
-                                f_min[kk] = f_tmp
-                                x_min[kk, :] = x_tmp
-                    # If no improvement, decay the mesh down to the tolerance
-                    else:
-                        if any([mesh[i, i] < 1.0e-4 for i in range(self.n)]):
-                            break
-                        else:
-                            mesh = mesh * 0.5
-            # Append the found minima to the results list
-            x_cand_ind = np.argmin(f_min)
-            result.append(x_min[x_cand_ind, :].copy())
-        return np.asarray(result)
-
-
-class QuickGPS(SurrogateOptimizer):
-    """ Use Generalized Pattern Search (GPS) to identify local solutions.
-
-    Applies GPS to the surrogate problem, in order to identify design
-    points that are locally Pareto optimal, with respect to the surrogate
-    problem. Sorts poll directions by most recently used and attempts to
-    step in promising directions in late iterations.
-
-    """
-
-    # Slots for the QuickGPS class
-    __slots__ = ['n', 'lb', 'ub', 'acquisitions', 'budget', 'constraints',
-                 'objectives', 'simulations', 'gradients', 'resetObjectives',
-                 'penalty_func', 'sim_sd', 'restarts', 'momentum']
-
-    def __init__(self, o, lb, ub, hyperparams):
-        """ Constructor for the QuickGPS class.
-
-        Args:
-            o (int): The number of objectives.
-
-            lb (numpy.ndarray): A 1d array of lower bounds for the design
-                region. The number of design variables is inferred from the
-                dimension of lb.
-
-            ub (numpy.ndarray): A 1d array of upper bounds for the design
-                region. The dimension must match ub.
-
-            hyperparams (dict): A dictionary of hyperparameters for the
-                optimization procedure. It may contain the following:
-                 * opt_budget (int): The GPS iteration limit (default: 1000).
-                 * opt_restarts (int): Number of multisolve restarts per
-                   scalarization (default: n+1).
-
-        Returns:
-            SurrogateOptimizer: A new SurrogateOptimizer object.
-
-        """
-
-        # Check inputs
-        xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
-        self.n = lb.size
-        self.lb = lb
-        self.ub = ub
+        self.q_ind = 0
         # Check that the contents of hyperparams is legal
         if 'opt_restarts' in hyperparams:
             if isinstance(hyperparams['opt_restarts'], int):
@@ -300,7 +92,7 @@ class QuickGPS(SurrogateOptimizer):
         # Check that the contents of hyperparams is legal
         if 'opt_momentum' in hyperparams:
             if isinstance(hyperparams['opt_momentum'], float):
-                if 0 <= hyperparams['opt_budget'] < 1:
+                if 0 <= hyperparams['opt_momentum'] < 1:
                     self.momentum = hyperparams['opt_momentum']
                 else:
                     raise ValueError("hyperparams['opt_momentum'] "
@@ -313,9 +105,29 @@ class QuickGPS(SurrogateOptimizer):
         self.acquisitions = []
         return
 
-    @profile
+    def __obj_func__(self, x_in):
+        """ A wrapper for the objective function and acquisition.
+
+        Args:
+            x_in (np.ndarray): A 1d array with the design point to evaluate.
+
+        Returns:
+            float: The result of acquisition.scalarize(f(x_in, sim(x_in))).
+
+        """
+
+        sx_in = np.asarray(self.simulations(x_in))
+        if self.acquisitions[self.q_ind].useSD():
+            sdx_in = np.asarray(self.sim_sd(x_in))
+        else:
+            sdx_in = np.zeros(sx_in.size)
+        fx_in = np.asarray(self.penalty_func(x_in, sx_in)).flatten()
+        ax = self.acquisitions[self.q_ind].scalarize(fx_in, x_in,
+                                                     sx_in, sdx_in)
+        return ax
+
     def solve(self, x):
-        """ Solve the surrogate problem using generalized pattern search (GPS).
+        """ Solve the surrogate problem using a generalized pattern search.
 
         Args:
             x (np.ndarray): A 2d array containing a list of feasible
@@ -342,117 +154,23 @@ class QuickGPS(SurrogateOptimizer):
         for j, acquisition in enumerate(self.acquisitions):
             # Create a new trust region
             rad = self.resetObjectives(x[j, :])
-            mesh_size = np.zeros(self.n)
-            m_tmp = np.zeros(self.n)
             lb_tmp = np.zeros(self.n)
             ub_tmp = np.ones(self.n)
             for i in range(self.n):
                 lb_tmp[i] = max(self.lb[i], x[j, i] - rad)
                 ub_tmp[i] = min(self.ub[i], x[j, i] + rad)
-            # Initialize temp arrays
-            f_min = np.zeros(self.restarts)
-            x_center = np.zeros(self.n)
-            x_min = np.zeros((self.restarts, self.n))
-            x_tmp = np.zeros(self.n)
-            # Loop over restarts
-            for kk in range(self.restarts):
-                # Reset the mesh dimensions
-                mesh_size[:] = 0.25 * (ub_tmp[:] - lb_tmp[:])
-                mesh = np.vstack((np.zeros((1,self.n)),
-                                  np.diag(ub_tmp[:] - lb_tmp[:]),
-                                  -np.diag(ub_tmp[:] - lb_tmp[:])))
-                mesh_tol = max(1.0e-8, np.min((ub_tmp - lb_tmp) * 1.0e-4))
-                # Evaluate the starting point
-                sx = np.asarray(self.simulations(x[j, :]))
-                if acquisition.useSD():
-                    sdx = np.asarray(self.sim_sd(x[j, :]))
-                else:
-                    sdx = np.zeros(sx.size)
-                if kk == 0:
-                    x_min[kk, :] = x[j, :]
-                else:
-                    x_min[kk, :] = (np.random.random_sample(self.n) *
-                                    (ub_tmp - lb_tmp) + lb_tmp)
-                fx = np.asarray(self.penalty_func(x_min[kk, :], sx))
-                f_min[kk] = acquisition.scalarize(fx.flatten(), x_min[kk, :],
-                                                  sx, sdx)
-                # Take n+1 iterations to start
-                for k in range(self.n+1):
-                    # Track whether or not there is improvement
-                    improve = False
-                    x_center[:] = x_min[kk, :]
-                    for i, mi in enumerate(mesh[1:, :]):
-                        # Evaluate x + mi
-                        x_tmp[:] = x_center[:] + mi[:] * mesh_size[:]
-                        if np.any((x_tmp > ub_tmp) + (x_tmp < lb_tmp)):
-                            f_tmp = np.inf
-                        else:
-                            sx = np.asarray(self.simulations(x_tmp))
-                            if acquisition.useSD():
-                                sdx = self.sim_sd(x_tmp)
-                            else:
-                                sdx = 0.0
-                            fx = self.penalty_func(x_tmp, sx)
-                            f_tmp = acquisition.scalarize(fx, x_tmp, sx, sdx)
-                        # Check for improvement
-                        if f_tmp + 1.0e-8 < f_min[kk]:
-                            f_min[kk] = f_tmp
-                            x_min[kk, :] = x_tmp[:]
-                            m_min = i + 1
-                            improve = True
-                    # If there was improvement, shuffle the directions
-                    if improve:
-                        m_tmp[:] = mesh[m_min, :]
-                        mesh[2:m_min, :] = mesh[1:m_min-1, :]
-                        mesh[1, :] = m_tmp[:]
-                    # If no improvement, decay the mesh down to the tolerance
-                    else:
-                        if np.any(mesh_size[:] < mesh_tol):
-                            break
-                        else:
-                            mesh_size[:] = mesh_size[:] * 0.5
-                # Take the remaining iterations
-                for k in range(self.n+1, self.budget):
-                    # Track whether or not there is improvement
-                    improve = False
-                    x_center[:] = x_min[kk, :]
-                    for i, mi in enumerate(mesh[:, :]):
-                        # Evaluate x + mi
-                        x_tmp[:] = x_center[:] + np.rint(mi[:]) * mesh_size[:]
-                        if np.any((x_tmp > ub_tmp) + (x_tmp < lb_tmp)):
-                            f_tmp = np.inf
-                        else:
-                            sx = np.asarray(self.simulations(x_tmp))
-                            if acquisition.useSD():
-                                sdx = self.sim_sd(x_tmp)
-                            else:
-                                sdx = 0.0
-                            fx = self.penalty_func(x_tmp, sx)
-                            f_tmp = acquisition.scalarize(fx, x_tmp, sx, sdx)
-                        # Check for improvement
-                        if f_tmp + 1.0e-8 < f_min[kk]:
-                            f_min[kk] = f_tmp
-                            x_min[kk, :] = x_tmp[:]
-                            m_min = i
-                            improve = True
-                            break
-                    # If there was improvement, shuffle the directions
-                    if improve:
-                        mesh[0, :] = (mesh[0, :] * (1 - self.momentum) +
-                                      mesh[m_min, :] * self.momentum)
-                        if m_min > 0:
-                            m_tmp[:] = mesh[m_min, :]
-                            mesh[2:m_min, :] = mesh[1:m_min-1, :]
-                            mesh[1, :] = m_tmp[:]
-                    # If no improvement, decay the mesh down to the tolerance
-                    else:
-                        if np.any(mesh_size[:] < mesh_tol):
-                            break
-                        else:
-                            mesh_size[:] = mesh_size[:] * 0.5
+            # Get a candidate
+            self.q_ind = j
+            mesh_tol = max(1.0e-8, np.min((ub_tmp - lb_tmp) * 1.0e-4))
+            xj = __accelerated_pattern_search__(self.n, lb_tmp, ub_tmp, x[j],
+                                                self.__obj_func__,
+                                                ibudget=self.budget,
+                                                mesh_start=0.25,
+                                                mesh_tol=mesh_tol,
+                                                momentum=self.momentum,
+                                                istarts=self.restarts)
             # Append the found minima to the results list
-            x_cand_ind = np.argmin(f_min)
-            result.append(x_min[x_cand_ind, :].copy())
+            result.append(xj)
         return np.asarray(result)
 
 
@@ -460,15 +178,16 @@ class GlobalGPS(SurrogateOptimizer):
     """ Use randomized search globally followed by GPS locally.
 
     Use ``RandomSearch`` to globally search the design space (search phase)
-    followed by ``QuickGPS`` to refine the potentially efficient solutions
+    followed by ``LocalGPS`` to refine the potentially efficient solutions
     (poll phase).
 
     """
 
     # Slots for the GlobalGPS class
-    __slots__ = ['n', 'lb', 'ub', 'acquisitions', 'constraints', 'objectives',
-                 'simulations', 'gradients', 'resetObjectives', 'penalty_func',
-                 'search_budget', 'gps_budget', 'sim_sd']
+    __slots__ = ['n', 'o', 'lb', 'ub', 'acquisitions', 'constraints',
+                 'objectives', 'simulations', 'gradients', 'resetObjectives',
+                 'penalty_func', 'opt_budget', 'gps_budget', 'sim_sd',
+                 'momentum']
 
     def __init__(self, o, lb, ub, hyperparams):
         """ Constructor for the GlobalGPS class.
@@ -486,9 +205,9 @@ class GlobalGPS(SurrogateOptimizer):
             hyperparams (dict): A dictionary of hyperparameters for the
                 optimization procedure. It may contain the following:
                  * opt_budget (int): The function evaluation budget
-                   (default: 10,000)
+                   (default: 1500)
                  * gps_budget (int): The number of the total opt_budget
-                   evaluations that will be used by GPS (default: half
+                   evaluations that will be used by GPS (default: 2/3
                    of opt_budget).
 
         Returns:
@@ -499,42 +218,73 @@ class GlobalGPS(SurrogateOptimizer):
         # Check inputs
         xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
         self.n = lb.size
+        self.o = o
         self.lb = lb
         self.ub = ub
-        # Check that the contents of hyperparams are legal
+        # Check that the contents of hyperparams is legal
         if 'opt_budget' in hyperparams:
             if isinstance(hyperparams['opt_budget'], int):
                 if hyperparams['opt_budget'] < 1:
                     raise ValueError("hyperparams['opt_budget'] "
                                      "must be positive")
                 else:
-                    budget = hyperparams['opt_budget']
+                    self.opt_budget = hyperparams['opt_budget']
             else:
                 raise TypeError("hyperparams['opt_budget'] "
                                  "must be an integer")
         else:
-            budget = 1000
-        # Check the GPS budget
+            self.opt_budget = 1500
+        # Check that the contents of hyperparams is legal
         if 'gps_budget' in hyperparams:
             if isinstance(hyperparams['gps_budget'], int):
-                if hyperparams['gps_budget'] < 1:
+                if hyperparams['gps_budget'] < 1 or \
+                   hyperparams['gps_budget'] >= self.opt_budget:
                     raise ValueError("hyperparams['gps_budget'] "
-                                     "must be positive")
-                elif hyperparams['gps_budget'] > budget:
-                    raise ValueError("hyperparams['gps_budget'] "
-                                     "must be less than "
+                                     "must be between 1 and "
                                      "hyperparams['opt_budget']")
                 else:
                     self.gps_budget = hyperparams['gps_budget']
             else:
-                raise TypeError("hyperparams['gps_budget'] "
+                raise TypeError("hyperparams['opt_budget'] "
                                  "must be an integer")
         else:
-            self.gps_budget = 1000
-        self.search_budget = budget
-        # Initialize the list of acquisition functions
+            self.gps_budget = int(2 * self.opt_budget / 3)
+        # Check that the contents of hyperparams is legal
+        if 'opt_momentum' in hyperparams:
+            if isinstance(hyperparams['opt_momentum'], float):
+                if 0 <= hyperparams['opt_momentum'] < 1:
+                    self.momentum = hyperparams['opt_momentum']
+                else:
+                    raise ValueError("hyperparams['opt_momentum'] "
+                                     "must be in [0, 1)")
+            else:
+                raise TypeError("hyperparams['opt_momentum'] "
+                                 "must be a float")
+        else:
+            self.momentum = 9e-1
         self.acquisitions = []
         return
+
+    def __obj_func__(self, x_in):
+        """ A wrapper for the objective function and acquisition.
+
+        Args:
+            x_in (np.ndarray): A 1d array with the design point to evaluate.
+
+        Returns:
+            float: The result of acquisition.scalarize(f(x_in, sim(x_in))).
+
+        """
+
+        sx_in = np.asarray(self.simulations(x_in))
+        if self.acquisitions[self.q_ind].useSD():
+            sdx_in = np.asarray(self.sim_sd(x_in))
+        else:
+            sdx_in = np.zeros(sx_in.size)
+        fx_in = np.asarray(self.penalty_func(x_in, sx_in)).flatten()
+        ax = self.acquisitions[self.q_ind].scalarize(fx_in, x_in,
+                                                     sx_in, sdx_in)
+        return ax
 
     def solve(self, x):
         """ Solve the surrogate problem by using random search followed by GPS.
@@ -549,7 +299,7 @@ class GlobalGPS(SurrogateOptimizer):
 
         """
 
-        from .random_search import RandomSearch
+        from parmoo.util import updatePF
 
         # Check that x is legal
         if isinstance(x, np.ndarray):
@@ -560,26 +310,209 @@ class GlobalGPS(SurrogateOptimizer):
                                  "of acquisition functions")
         else:
             raise TypeError("x must be a numpy array")
-        # Do a global search to get global solutions
-        gs = RandomSearch(self.n, self.lb, self.ub,
-                          {'opt_budget': self.search_budget})
-        gs.setObjective(self.objectives)
-        gs.setSimulation(self.simulations, self.sim_sd)
-        gs.setPenalty(self.penalty_func, self.gradients)
-        gs.setConstraints(self.constraints)
-        gs.addAcquisition(*self.acquisitions)
-        gs_soln = gs.solve(x)
-        gps_budget_loc = int(self.gps_budget / gs_soln.shape[0])
-        # Do a local search to refine the global solution
-        ls = QuickGPS(self.n, self.lb, self.ub,
-                      {'opt_budget': gps_budget_loc,
-                       'opt_restarts': 1})
-        ls.setObjective(self.objectives)
-        ls.setSimulation(self.simulations, self.sim_sd)
-        ls.setPenalty(self.penalty_func, self.gradients)
-        ls.setConstraints(self.constraints)
-        ls.addAcquisition(*self.acquisitions)
-        ls.setReset(self.resetObjectives)
-        ls_soln = ls.solve(gs_soln)
-        # Return the list of local solutions
-        return ls_soln
+        # Set the batch size
+        batch_size = 1000
+        # Initialize lists/arrays
+        result = []
+        lb_tmp = np.zeros(self.n)
+        ub_tmp = np.ones(self.n)
+        # For each acquisition function
+        for j, acq in enumerate(self.acquisitions):
+            # Create a new trust region
+            rad = self.resetObjectives(x[j, :])
+            lb_old = lb_tmp
+            ub_old = ub_tmp
+            for i in range(self.n):
+                lb_tmp[i] = max(self.lb[i], x[j, i] - rad)
+                ub_tmp[i] = min(self.ub[i], x[j, i] + rad)
+            # Check if TR has changed
+            if j == 0 or np.any(np.abs(lb_old - lb_tmp) +
+                                np.abs(ub_old - ub_tmp) > 1.0e-8):
+                # Initialize the database
+                data = {'x_vals': np.zeros((batch_size, self.n)),
+                        'f_vals': np.zeros((batch_size, self.o)),
+                        'c_vals': np.zeros((batch_size, 0))}
+                # Loop over batch size until k == budget
+                k = 0
+                nondom = {}
+                search_budget = self.opt_budget = self.gps_budget
+                while (k < search_budget):
+                    # Check how many new points to generate
+                    k_new = min(search_budget, k + batch_size) - k
+                    if k_new < batch_size:
+                        data['x_vals'] = np.zeros((k_new, self.n))
+                        data['f_vals'] = np.zeros((k_new, self.o))
+                        data['c_vals'] = np.zeros((k_new, 0))
+                    # Randomly generate k_new new points
+                    for i in range(k_new):
+                        if i == 0:
+                            xi = x[j, :]
+                        else:
+                            xi = (np.random.sample(self.n) *
+                                  (ub_tmp[:] - lb_tmp[:]) + lb_tmp[:])
+                        data['x_vals'][i, :] = xi[:]
+                        data['f_vals'][i, :] = self.penalty_func(xi)
+                    # Update the PF
+                    nondom = updatePF(data, nondom)
+                    k += k_new
+            f_vals = []
+            if acq.useSD():
+                f_vals = [acq.scalarize(fi, xi, self.simulations(xi),
+                                        self.sim_sd(xi))
+                          for fi, xi in zip(nondom['f_vals'],
+                                            nondom['x_vals'])]
+            else:
+                m = self.simulations(nondom['x_vals'][0]).size
+                f_vals = [acq.scalarize(fi, xi, self.simulations(xi),
+                                        np.zeros(m))
+                          for fi, xi in zip(nondom['f_vals'],
+                                            nondom['x_vals'])]
+            imin = np.argmin(np.asarray([f_vals]))
+            x0 = nondom['x_vals'][imin, :].copy()
+            # Get a candidate
+            self.q_ind = j
+            mesh_tol = max(1.0e-8, np.min((ub_tmp - lb_tmp) * 1.0e-4))
+            xj = __accelerated_pattern_search__(self.n, lb_tmp, ub_tmp, x0,
+                                                self.__obj_func__,
+                                                ibudget=self.gps_budget,
+                                                mesh_start=0.1,
+                                                mesh_tol=mesh_tol,
+                                                momentum=self.momentum,
+                                                istarts=1)
+            # Append the found minima to the results list
+            result.append(xj)
+        return np.asarray(result)
+
+
+@profile
+def __accelerated_pattern_search__(n, lb, ub, x0, obj_func, ibudget,
+                                   mesh_start=0.25, mesh_tol=1.0e-8,
+                                   momentum=0.9, istarts=1):
+    """ Solve the optimization problem min obj_func(x) over x in [lb, ub].
+
+    Uses pattern search with 1 additional poll direction inspired by
+    Nesterov's momentum.
+
+    Args:
+        n (int): The dimension of the search space.
+
+        lb (np.ndarray): A 1D array of length n specifying lower bounds on
+            the search space.
+
+        ub (np.ndarray): A 1D array of length n specifying upper bounds on
+            the search space.
+
+        x0 (np.ndarray): A 1D array of length n specifying the initial
+            location to sample when warm-starting search.
+
+        obj_func (function): A function that takes a 1D numpy.ndarray of
+            size n as input (x) and returns the value of f(x).
+
+        ibudget (int): The iteration limit for pattern search. The total
+            number of calls to obj_func could be up to 2n * ibudget + 1,
+            but typically will be much less.
+
+        mesh_start (float or numpy.ndarray, optional): The initial mesh
+            spacing. If an array is given, must be 1D of size n. Defaults
+            to 25% of ub-lb.
+
+        mesh_tol (float or numpy.ndarray, optional): The tolerance for the
+            mesh. If an array is given, must be 1D of size n. Defaults to
+            1.0e-8.
+
+        momentum (float, optional): The decay rate on the momentum term in
+            the accelerated poll direction. Defaults to 0.9.
+
+        istarts (int, optional): Number of times to (re)start if
+            using the multistart option. Defaults to 1 (no restarts).
+
+    Returns:
+        numpy.ndarray(n): The best x observed so far (minimizer of obj_func).
+
+    """
+
+    # Initialize O(n)-sized work arrays and constants
+    f_min = np.zeros(istarts)
+    m_tmp = np.zeros(n)
+    mesh_size = np.zeros(n)
+    x_center = np.zeros(n)
+    x_min = np.zeros((istarts, n))
+    x_tmp = np.zeros(n)
+    # Loop over all starts
+    for kk in range(istarts):
+        # Reset the mesh dimensions
+        if isinstance(mesh_start, float):
+            mesh_size[:] = mesh_start * (ub[:] - lb[:])
+        else:
+            mesh_size[:] = mesh_start[:]
+        mesh = np.vstack((np.zeros((1, n)),
+                          np.diag(ub[:] - lb[:]),
+                          -np.diag(ub[:] - lb[:])))
+        # Evaluate the starting point or random point
+        if kk == 0:
+            x_min[kk, :] = x0[:]
+        else:
+            x_min[kk, :] = np.random.random_sample(n) * (ub - lb) + lb
+        f_min[kk] = obj_func(x_min[kk])
+        # Take n+1 iterations to get "momentum" started
+        for k in range(n+1):
+            improve = False
+            x_center[:] = x_min[kk, :]
+            for i, mi in enumerate(mesh[1:, :]):
+                # Evaluate x + mi
+                x_tmp[:] = x_center[:] + mi[:] * mesh_size[:]
+                if np.any((x_tmp > ub) + (x_tmp < lb)):
+                    f_tmp = np.inf
+                else:
+                    f_tmp = obj_func(x_tmp)
+                # Check for improvement
+                if f_tmp + 1.0e-8 < f_min[kk]:
+                    f_min[kk] = f_tmp
+                    x_min[kk, :] = x_tmp[:]
+                    m_min = i + 1
+                    improve = True
+            # If there was improvement, shuffle the directions
+            if improve:
+                m_tmp[:] = mesh[m_min, :]
+                mesh[2:m_min, :] = mesh[1:m_min-1, :]
+                mesh[1, :] = m_tmp[:]
+            # If no improvement, decay the mesh down to the tolerance
+            else:
+                if np.any(mesh_size[:] < mesh_tol):
+                    break
+                else:
+                    mesh_size[:] *= 0.5
+        # Take the remaining iterations
+        for k in range(n+1, ibudget):
+            improve = False
+            x_center[:] = x_min[kk, :]
+            for i, mi in enumerate(mesh[:, :]):
+                # Evaluate x + mi
+                x_tmp[:] = x_center[:] + np.rint(mi[:]) * mesh_size[:]
+                if np.any((x_tmp > ub) + (x_tmp < lb)):
+                    f_tmp = np.inf
+                else:
+                    f_tmp = obj_func(x_tmp)
+                # Check for improvement
+                if f_tmp + 1.0e-8 < f_min[kk]:
+                    f_min[kk] = f_tmp
+                    x_min[kk, :] = x_tmp[:]
+                    m_min = i
+                    improve = True
+                    break
+            # If there was improvement, update moment and shuffle directions
+            if improve:
+                mesh[0, :] *= (1 - momentum)
+                mesh[0, :] += (mesh[m_min, :] * momentum)
+                if m_min > 0:
+                    m_tmp[:] = mesh[m_min, :]
+                    mesh[2:m_min, :] = mesh[1:m_min-1, :]
+                    mesh[1, :] = m_tmp[:]
+            # If no improvement, decay the mesh down to the tolerance
+            else:
+                if np.any(mesh_size[:] < mesh_tol):
+                    break
+                else:
+                    mesh_size[:] *= 0.5
+    # Return the "best" of the multistarts
+    return x_min[np.argmin(f_min), :].copy()

--- a/parmoo/optimizers/gps_search.py
+++ b/parmoo/optimizers/gps_search.py
@@ -384,7 +384,6 @@ class GlobalGPS(SurrogateOptimizer):
         return np.asarray(result)
 
 
-@profile
 def __accelerated_pattern_search__(n, lb, ub, x0, obj_func, ibudget,
                                    mesh_start=0.25, mesh_tol=1.0e-8,
                                    momentum=0.9, istarts=1):

--- a/parmoo/optimizers/gps_search.py
+++ b/parmoo/optimizers/gps_search.py
@@ -452,7 +452,9 @@ def __accelerated_pattern_search__(n, lb, ub, x0, obj_func, ibudget,
             x_min[kk, :] = x0[:]
         else:
             x_min[kk, :] = np.random.random_sample(n) * (ub - lb) + lb
-        f_min[kk] = obj_func(x_min[kk])
+        f0 = obj_func(x_min[kk])
+        f_tol = max(min(abs(f0), 1.0e-8), 1.0e-16)
+        f_min[kk] = f0
         # Take n+1 iterations to get "momentum" started
         for k in range(n+1):
             improve = False
@@ -465,7 +467,7 @@ def __accelerated_pattern_search__(n, lb, ub, x0, obj_func, ibudget,
                 else:
                     f_tmp = obj_func(x_tmp)
                 # Check for improvement
-                if f_tmp + 1.0e-8 < f_min[kk]:
+                if f_min[kk] - f_tmp > f_tol:
                     f_min[kk] = f_tmp
                     x_min[kk, :] = x_tmp[:]
                     m_min = i + 1
@@ -493,7 +495,7 @@ def __accelerated_pattern_search__(n, lb, ub, x0, obj_func, ibudget,
                 else:
                     f_tmp = obj_func(x_tmp)
                 # Check for improvement
-                if f_tmp + 1.0e-8 < f_min[kk]:
+                if f_min[kk] - f_tmp > f_tol:
                     f_min[kk] = f_tmp
                     x_min[kk, :] = x_tmp[:]
                     m_min = i

--- a/parmoo/tests/unit_tests/test_gps_search.py
+++ b/parmoo/tests/unit_tests/test_gps_search.py
@@ -164,8 +164,8 @@ def test_GlobalGPS():
                               'gps_budget': 1000})
     # Initialize the problem correctly, with and without an optional budget
     GlobalGPS(o, lb, ub, {'opt_budget': 200})
-    GlobalGPS(o, lb, ub, {'opt_budget': 200, 'gps_budget': 100})
-    opt = GlobalGPS(o, lb, ub, {'opt_budget': 5000, 'gps_budget': 2000})
+    GlobalGPS(o, lb, ub, {'opt_budget': 5000, 'gps_budget': 2000})
+    opt = GlobalGPS(o, lb, ub, {})
     # Try to add some bad objectives, constraints, and acquisitions
     with pytest.raises(TypeError):
         opt.setObjective(5)
@@ -201,7 +201,7 @@ def test_GlobalGPS():
     x2_soln = np.eye(n)[1]
     x2_soln[n-1] = 0.1
     # eps is the tolerance for rejecting a solution as incorrect
-    eps = 0.05 # need a larger tolerance in case starting f0 is already small
+    eps = 0.01
     # Check that the computed solutions are within eps of the truth
     assert (np.linalg.norm(x1 - x1_soln) < eps)
     assert (np.linalg.norm(x2 - x2_soln) < eps)

--- a/parmoo/tests/unit_tests/test_gps_search.py
+++ b/parmoo/tests/unit_tests/test_gps_search.py
@@ -165,7 +165,7 @@ def test_GlobalGPS():
     # Initialize the problem correctly, with and without an optional budget
     GlobalGPS(o, lb, ub, {'opt_budget': 200})
     GlobalGPS(o, lb, ub, {'opt_budget': 200, 'gps_budget': 100})
-    opt = GlobalGPS(o, lb, ub, {})
+    opt = GlobalGPS(o, lb, ub, {'opt_budget': 5000, 'gps_budget': 2000})
     # Try to add some bad objectives, constraints, and acquisitions
     with pytest.raises(TypeError):
         opt.setObjective(5)
@@ -201,7 +201,7 @@ def test_GlobalGPS():
     x2_soln = np.eye(n)[1]
     x2_soln[n-1] = 0.1
     # eps is the tolerance for rejecting a solution as incorrect
-    eps = 0.01
+    eps = 0.05 # need a larger tolerance in case starting f0 is already small
     # Check that the computed solutions are within eps of the truth
     assert (np.linalg.norm(x1 - x1_soln) < eps)
     assert (np.linalg.norm(x2 - x2_soln) < eps)


### PR DESCRIPTION
Improvements to our pattern search implementations to accelerate convergence and improve robustness to finding "good" local minima quickly.  Very useful to have an efficient pattern search implementation for ease of comparison between various surrogate modeling and acquisition function techniques, since it can be locally convergent for most reasonable methods with little modification or need for gradients to be implemented:

 - first ``n+1`` iterations check all poll directions (axis aligned) before taking step to make sure we get a nice start
 - after first ``n+1`` iterations, remaining ``k-n-1`` iterations step opportunistically this includes:
    - as soon as a good direction is found, take a step
    - first direction checked is *not* one of the standard poll directions, it is a nesterov's momentum step binned to the nearest vertex on the mesh
    - remaining directions are ordered by most recently used
    - my line profiling shows that this is a good policy, with the "momentum" step and other recently-used directions being frequently chosen in later iterations
 - implementation of pattern search moved down into a private method outside any of the pattern-search classes, in order to avoid maintaining duplicate code
 - I also needed to slightly re-work the ``random_search`` classes, in order to make them usable in a trust-region solver
 - ``GlobalGPS`` now does a random search followed by pattern search off the "best" solution from the random search -- this seems to be an extremely fast method that is quite good for any of the trust region surrogates