### PR TITLE
Feature/no jit

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -1,6 +1,6 @@
+jax>=0.4.8
 numpy>=1.8.2
 scipy>=1.10.0
-pyDOE>=0.3.8
 libensemble==0.9.3
 pandas>=0.3.0
 plotly>=5.20.0

--- a/parmoo/embeddings/default_embedders.py
+++ b/parmoo/embeddings/default_embedders.py
@@ -12,7 +12,6 @@ This includes the following classes:
 
 """
 
-from jax import jit
 from jax import numpy as jnp
 import numpy as np
 from parmoo.structs import Embedder
@@ -82,10 +81,6 @@ class ContinuousEmbedder(Embedder):
         self.scale = jnp.ones(1) * (ub - lb)
         self.shift = jnp.ones(1) * lb
         self.scaled_des_tol = np.ones(1) * des_tol / self.scale
-        # Jit the embedder and extractor
-        self.embed = jit(self._embed)
-        self.embed_grad = jit(self._embed_grad)
-        self.extract = jit(self._extract)
         return
 
     def getLatentDesTols(self):
@@ -150,7 +145,7 @@ class ContinuousEmbedder(Embedder):
 
         return np.ones(1)
 
-    def _embed(self, x):
+    def embed(self, x):
         """ Embed a design input as n-dimensional vector for ParMOO.
 
         Args:
@@ -164,7 +159,7 @@ class ContinuousEmbedder(Embedder):
 
         return jnp.minimum(jnp.maximum((x - self.shift) / self.scale, 0), 1)
 
-    def _embed_grad(self, dx):
+    def embed_grad(self, dx):
         """ Embed a partial design gradient as a vector for ParMOO.
 
         Args:
@@ -178,7 +173,7 @@ class ContinuousEmbedder(Embedder):
 
         return dx / self.scale
 
-    def _extract(self, x):
+    def extract(self, x):
         """ Extract a design variable from an n-dimensional vector.
 
         Args:
@@ -247,10 +242,6 @@ class IntegerEmbedder(Embedder):
         self.scale = jnp.ones(1) * (ub - lb)
         self.shift = jnp.ones(1) * lb
         self.scaled_des_tol = np.ones(1) * 0.5 / self.scale
-        # Jit the embedder and extractor
-        self.embed = jit(self._embed)
-        self.embed_grad = jit(self._embed_grad)
-        self.extract = jit(self._extract)
         return
 
     def getLatentDesTols(self):
@@ -315,7 +306,7 @@ class IntegerEmbedder(Embedder):
 
         return np.ones(1)
 
-    def _embed(self, x):
+    def embed(self, x):
         """ Embed a design input as n-dimensional vector for ParMOO.
 
         Args:
@@ -329,7 +320,7 @@ class IntegerEmbedder(Embedder):
 
         return jnp.minimum(jnp.maximum((x - self.shift) / self.scale, 0), 1)
 
-    def _embed_grad(self, dx):
+    def embed_grad(self, dx):
         """ Embed a partial design gradient as a vector for ParMOO.
 
         Args:
@@ -343,7 +334,7 @@ class IntegerEmbedder(Embedder):
 
         return dx / self.scale
 
-    def _extract(self, x):
+    def extract(self, x):
         """ Extract a design variable from an n-dimensional vector.
 
         Args:
@@ -378,7 +369,6 @@ class CategoricalEmbedder(Embedder):
         """
 
         # Error handling and extracting input types
-        jittable = True
         if isinstance(settings, dict) and 'levels' in settings:
             levels = settings['levels']
             if isinstance(levels, int):
@@ -403,7 +393,6 @@ class CategoricalEmbedder(Embedder):
                 except TypeError:
                     self.alabels = np.array(levels)
                     self.in_type = 'U25'
-                    jittable = False
             else:
                 raise TypeError("settings['levels'] must be an int or list")
         elif isinstance(settings, dict):
@@ -420,15 +409,6 @@ class CategoricalEmbedder(Embedder):
         self.des_tol = np.sqrt(0.5) / self.scale
         self.zeros = jnp.zeros(n_lvls)
         self.ones = jnp.ones(n_lvls)
-        # Jit the embedder and extractor
-        if jittable:
-            self.embed = jit(self._embed)
-            self.embed_grad = jit(self._embed_grad)
-            self.extract = jit(self._extract)
-        else:
-            self.embed = self._embed
-            self.embed_grad = self._embed_grad
-            self.extract = self._extract
         return
 
     def getLatentDesTols(self):
@@ -493,7 +473,7 @@ class CategoricalEmbedder(Embedder):
 
         return np.ones(self.des_tol.size)
 
-    def _embed(self, x):
+    def embed(self, x):
         """ Embed a design input as n-dimensional vector for ParMOO.
 
         Args:
@@ -509,7 +489,7 @@ class CategoricalEmbedder(Embedder):
         xx1 = (jnp.dot(xx - self.cent, self.rot) - self.shift) / self.scale
         return jnp.minimum(jnp.maximum(xx1, 0), 1)
 
-    def _embed_grad(self, dx):
+    def embed_grad(self, dx):
         """ Embed a partial design gradient as a vector for ParMOO.
 
         Args:
@@ -523,7 +503,7 @@ class CategoricalEmbedder(Embedder):
 
         return jnp.zeros(self.des_tol.size)
 
-    def _extract(self, x):
+    def extract(self, x):
         """ Extract a design variable from an n-dimensional vector.
 
         Args:
@@ -599,10 +579,6 @@ class IdentityEmbedder(Embedder):
                                  "up to the design tolerance")
         else:
             raise TypeError("settings must be a dictionary")
-        # Jit the embedder and extractor
-        self.embed = jit(self._embed)
-        self.embed_grad = jit(self._embed_grad)
-        self.extract = jit(self._extract)
         return
 
     def getLatentDesTols(self):
@@ -667,7 +643,7 @@ class IdentityEmbedder(Embedder):
 
         return self.ub * np.ones(1)
 
-    def _embed(self, x):
+    def embed(self, x):
         """ Embed a design input as n-dimensional vector for ParMOO.
 
         Args:
@@ -680,7 +656,7 @@ class IdentityEmbedder(Embedder):
 
         return jnp.ones(1) * x
 
-    def _embed_grad(self, dx):
+    def embed_grad(self, dx):
         """ Embed a partial design gradient as a vector for ParMOO.
 
         Args:
@@ -694,7 +670,7 @@ class IdentityEmbedder(Embedder):
 
         return jnp.ones(1) * dx
 
-    def _extract(self, x):
+    def extract(self, x):
         """ Extract a design variable from an n-dimensional vector.
 
         Args:

--- a/parmoo/extras/libe.py
+++ b/parmoo/extras/libe.py
@@ -775,6 +775,7 @@ class libE_MOOP(MOOP):
         persis_info = {}
         for i in range(nworkers + 1):
             persis_info[i] = {}
+        self.moop.compile()
         persis_info[1]['moop'] = self.moop
 
         exit_criteria = {'sim_max': sim_max, 'wallclock_max': wt_max}

--- a/parmoo/optimizers/lbfgsb.py
+++ b/parmoo/optimizers/lbfgsb.py
@@ -197,6 +197,9 @@ class GlobalSurrogate_BFGS(SurrogateOptimizer):
                     soln = res['x']
             # Append the found minima to the results list
             result.append(soln)
+        self.objectives = None
+        self.constraints = None
+        self.penalty_func = None
         return np.asarray(result)
 
 
@@ -460,6 +463,9 @@ class LocalSurrogate_BFGS(SurrogateOptimizer):
             result.append(soln)
             # We need to remember this "target" for later
             self.targets.append([x[j, :], rad, float(fj), j])
+        self.objectives = None
+        self.constraints = None
+        self.penalty_func = None
         return np.asarray(result)
 
     def save(self, filename):

--- a/parmoo/optimizers/pattern_search.py
+++ b/parmoo/optimizers/pattern_search.py
@@ -267,6 +267,9 @@ class LocalSurrogate_PS(SurrogateOptimizer):
             result.append(xj)
             # We need to remember this "target" for later
             self.targets.append([x[j, :], rad, fj, j])
+        self.objectives = None
+        self.constraints = None
+        self.penalty_func = None
         return np.asarray(result)
 
     def save(self, filename):
@@ -547,6 +550,9 @@ class GlobalSurrogate_PS(SurrogateOptimizer):
                                                  momentum=self.momentum,
                                                  istarts=1)
             result.append(xj)
+        self.objectives = None
+        self.constraints = None
+        self.penalty_func = None
         return np.asarray(result)
 
 

--- a/parmoo/optimizers/random_search.py
+++ b/parmoo/optimizers/random_search.py
@@ -167,4 +167,7 @@ class GlobalSurrogate_RS(SurrogateOptimizer):
                                                          nondom['x_vals'])]
             imin = np.argmin(np.asarray([f_vals]))
             results.append(nondom['x_vals'][imin, :])
+        self.objectives = None
+        self.constraints = None
+        self.penalty_func = None
         return np.asarray(results)

--- a/parmoo/surrogates/gaussian_proc.py
+++ b/parmoo/surrogates/gaussian_proc.py
@@ -392,7 +392,7 @@ class GaussRBF(SurrogateFunction):
         return
 
 
-# Private pure helper functions to be compiled via jax.jit()
+# Private pure helper functions
 
 @jit
 def _gaussian(r2, x_std_dev):

--- a/parmoo/tests/libe_tests/test_libe_gen.py
+++ b/parmoo/tests/libe_tests/test_libe_gen.py
@@ -35,7 +35,8 @@ if __name__ == "__main__":
     for i in range(n):
         moop.addDesign({'lb': 0.0, 'ub': 1.0})
     # Add simulation
-    moop.addSimulation({'m': o,
+    moop.addSimulation({'name': "DTLZ2",
+                        'm': o,
                         'sim_func': dtlz2_sim_named,
                         'hyperparams': {'search_budget': 100},
                         'search': LatinHypercube,
@@ -49,7 +50,7 @@ if __name__ == "__main__":
     # Add 4 acquisition functions
     for i in range(4):
         moop.addAcquisition({'acquisition': RandomConstraint})
-    
+    moop.compile()
     # Solve
     moop.solve(sim_max=200)
     assert(moop.getObjectiveData()['x1'].shape[0] == 200)

--- a/parmoo/tests/unit_tests/test_gps_search.py
+++ b/parmoo/tests/unit_tests/test_gps_search.py
@@ -66,27 +66,28 @@ def test_LocalSurrogate_PS():
         opt.setConstraints(lambda z1, z2, z3: np.zeros(1))
     with pytest.raises(TypeError):
         opt.addAcquisition(5)
-    # Add the correct objective and constraints
-    opt.setObjective(f)
-    opt.setConstraints(lambda z, sz: np.asarray([0.1 - z[2], z[2] - 0.6]))
-    opt.setSimulation(S, SD)
-    opt.setPenalty(L)
-    opt.addAcquisition(acqu1, acqu2, acqu3)
-    opt.setTrFunc(lambda x, r: 100.0)
     # Try to solve with invalid inputs to test error handling
     with pytest.raises(ValueError):
         opt.solve(np.zeros((3, n-1)))
     with pytest.raises(ValueError):
         opt.solve(np.zeros((4, n)))
+    # Set the acquisition and reset functions
+    opt.setSimulation(S, SD)
+    opt.addAcquisition(acqu1, acqu2, acqu3)
+    opt.setTrFunc(lambda x, r: 100.0)
     # Define the solution
     x1_soln = np.eye(n)[0]
     x1_soln[n-1] = 0.1
     x2_soln = np.eye(n)[1]
     x2_soln[n-1] = 0.1
-    # Solve the surrogate problem with LocalSurrogate_PS, starting from the centroid
+    # Solve the surrogate problem with LocalSurrogate_PS starting from centroid
     x = np.zeros((3, n))
     x[:] = 0.5
     for i in range(10):
+        # Add the correct objectives and constraints
+        opt.setObjective(f)
+        opt.setConstraints(lambda z, sz: np.asarray([0.1 - z[2], z[2] - 0.6]))
+        opt.setPenalty(L)
         (x1, x2, x3) = opt.solve(x)
         x[0] = x1
         x[1] = x2
@@ -179,6 +180,11 @@ def test_GlobalSurrogate_PS():
         opt.setConstraints(lambda z1, z2, z3: np.zeros(1))
     with pytest.raises(TypeError):
         opt.addAcquisition(5)
+    # Try to solve with invalid inputs to test error handling
+    with pytest.raises(ValueError):
+        opt.solve(np.zeros((3, n-1)))
+    with pytest.raises(ValueError):
+        opt.solve(np.zeros((4, n)))
     # Add the correct objective and constraints
     opt.setObjective(f)
     opt.setConstraints(lambda z, sz: np.asarray([0.1 - z[2], z[2] - 0.6]))
@@ -186,11 +192,6 @@ def test_GlobalSurrogate_PS():
     opt.setPenalty(L)
     opt.addAcquisition(acqu1, acqu2, acqu3)
     opt.setTrFunc(lambda x, r: 100.0)
-    # Try to solve with invalid inputs to test error handling
-    with pytest.raises(ValueError):
-        opt.solve(np.zeros((3, n-1)))
-    with pytest.raises(ValueError):
-        opt.solve(np.zeros((4, n)))
     # Solve the surrogate problem with GlobalSurrogate_PS, starting from the centroid
     x = np.zeros((3, n))
     x[:, :] = 0.5

--- a/parmoo/tests/unit_tests/test_lbfgsb.py
+++ b/parmoo/tests/unit_tests/test_lbfgsb.py
@@ -72,13 +72,6 @@ def test_GlobalSurrogate_BFGS():
         opt.setPenalty(lambda z1, z2, z3: np.zeros(1))
     with pytest.raises(TypeError):
         opt.addAcquisition(5)
-    # Add the correct objective and constraints
-    opt.setObjective(f)
-    opt.setConstraints(lambda z, sz: np.asarray([0.1 - z[2], z[2] - 0.6]))
-    opt.setSimulation(S, SD)
-    opt.setPenalty(L)
-    opt.addAcquisition(acqu1, acqu2, acqu3)
-    opt.setTrFunc(lambda x, r: 100.0)
     # Try to solve with invalid inputs to test error handling
     with pytest.raises(ValueError):
         opt.solve(np.zeros((3, n-1)))
@@ -86,7 +79,14 @@ def test_GlobalSurrogate_BFGS():
         opt.solve(np.zeros((4, n)))
     with pytest.raises(ValueError):
         opt.solve(-np.ones((3, n)))
-    # Solve the surrogate problem with GlobalSurrogate_BFGS, starting from the centroid
+    # Add the correct objective and constraints
+    opt.setObjective(f)
+    opt.setConstraints(lambda z, sz: np.asarray([0.1 - z[2], z[2] - 0.6]))
+    opt.setSimulation(S, SD)
+    opt.setPenalty(L)
+    opt.addAcquisition(acqu1, acqu2, acqu3)
+    opt.setTrFunc(lambda x, r: 100.0)
+    # Solve the surrogate problem with GlobalSurrogate_BFGS starting from centroid
     x0 = np.zeros((3, n))
     x0[:] = 0.5
     (x1, x2, x3) = opt.solve(x0)
@@ -181,13 +181,6 @@ def test_LocalSurrogate_BFGS():
         opt.setTrFunc(5)
     with pytest.raises(ValueError):
         opt.setTrFunc(lambda z1: 0.0)
-    # Add the correct objective and constraints
-    opt.setObjective(f)
-    opt.setConstraints(lambda z, sz: np.asarray([0.1 - z[2], z[2] - 0.6]))
-    opt.setSimulation(S, SD)
-    opt.setPenalty(L)
-    opt.addAcquisition(acqu1, acqu2, acqu3)
-    opt.setTrFunc(lambda x, r: 100.0)
     # Try to solve with invalid inputs to test error handling
     with pytest.raises(ValueError):
         opt.solve(np.zeros((3, n-1)))
@@ -195,6 +188,10 @@ def test_LocalSurrogate_BFGS():
         opt.solve(np.zeros((4, n)))
     with pytest.raises(ValueError):
         opt.solve(-np.ones((3, n)))
+    # Set the acquisition function and TR reset functions
+    opt.setSimulation(S, SD)
+    opt.addAcquisition(acqu1, acqu2, acqu3)
+    opt.setTrFunc(lambda x, r: 100.0)
     # Define the solution
     x1_soln = np.eye(n)[0]
     x1_soln[n-1] = 0.1
@@ -204,6 +201,10 @@ def test_LocalSurrogate_BFGS():
     x0 = np.zeros((3, n))
     x0[:] = 0.5
     for i in range(6):
+        # Add the correct objective and constraints
+        opt.setObjective(f)
+        opt.setConstraints(lambda z, sz: np.asarray([0.1 - z[2], z[2] - 0.6]))
+        opt.setPenalty(L)
         (x1, x2, x3) = opt.solve(x0)
         x0[0] = x1
         x0[1] = x2

--- a/parmoo/tests/unit_tests/test_moop_grads.py
+++ b/parmoo/tests/unit_tests/test_moop_grads.py
@@ -191,9 +191,9 @@ def test_MOOP_evaluate_penalty_grads():
     xx = moop2._embed({'x1': 1, 'x2': 1, 'x3': 1})
     assert (np.linalg.norm(eval_pen_jac(moop1, x) - eval_pen_jac(moop2, xx) < 1.0e-8))
     # Now check that after compiling, jax correctly propagates pen_jac
-    moop1._compile()
+    _, _, eval_pen1 = moop1._link()
     def pen_jac(x):
-        return moop1.evaluate_penalty(x, moop1.evaluate_surrogates(x))
+        return eval_pen1(x, moop1._evaluate_surrogates(x))
     moop1_pen_jac = jacrev(pen_jac)
     for xi in np.random.sample((5, 3)):
         dfdxi = moop1_pen_jac(xi)
@@ -347,10 +347,10 @@ def test_MOOP_evaluate_objective_grads():
     x = moop1._embed({'x1': 1, 'x2': 1, 'x3': 1})
     xx = moop2._embed({'x1': 1, 'x2': 1, 'x3': 1})
     assert (np.linalg.norm(eval_obj_jac(moop1, x) - eval_obj_jac(moop2, xx) < 1.0e-8))
+    eval_obj1, _, _ = moop1._link()
     # Now check that after compiling, jax correctly propagates obj_jac
-    moop1._compile()
     def obj_jac(x):
-        return moop1.evaluate_objectives(x, moop1.evaluate_surrogates(x))
+        return eval_obj1(x, moop1._evaluate_surrogates(x))
     moop1_obj_jac = jacrev(obj_jac)
     for xi in np.random.sample((5, 3)):
         dfdxi = moop1_obj_jac(xi)
@@ -485,10 +485,10 @@ def test_MOOP_evaluate_constraint_grads():
     x = moop1._embed({'x1': 1, 'x2': 1, 'x3': 1})
     xx = moop2._embed({'x1': 1, 'x2': 1, 'x3': 1})
     assert (np.linalg.norm(eval_con_jac(moop1, x) - eval_con_jac(moop2, xx) < 1.0e-8))
+    _, eval_con1, _ = moop1._link()
     # Now check that after compiling, jax correctly propagates con_jac
-    moop1._compile()
     def con_jac(x):
-        return moop1.evaluate_constraints(x, moop1.evaluate_surrogates(x))
+        return eval_con1(x, moop1._evaluate_surrogates(x))
     moop1_con_jac = jacrev(con_jac)
     for xi in np.random.sample((5, 3)):
         dfdxi = moop1_con_jac(xi)
@@ -552,7 +552,7 @@ def test_MOOP_solve_with_grads():
         return {"x1": 0}, {"sim1": 1, "sim2": jnp.zeros(2)}
 
     # Initialize 2 continuous MOOPs with 1 design var, 2 sims, and 3 objs
-    moop1 = MOOP(GlobalSurrogate_BFGS, hyperparams={'opt_restarts': 20,
+    moop1 = MOOP(GlobalSurrogate_BFGS, hyperparams={'opt_restarts': 2,
                                                     'np_random_gen': 0})
     moop1.addDesign({'lb': 0.0, 'ub': 1.0})
     moop1.addSimulation(g1, g2)

--- a/parmoo/tests/unit_tests/test_random_search.py
+++ b/parmoo/tests/unit_tests/test_random_search.py
@@ -67,6 +67,11 @@ def test_GlobalSurrogate_RS():
         opt.setConstraints(lambda z1, z2, z3: np.zeros(1))
     with pytest.raises(TypeError):
         opt.addAcquisition(5)
+    # Try to solve with invalid inputs to test error handling
+    with pytest.raises(ValueError):
+        opt.solve(np.zeros((3, n-1)))
+    with pytest.raises(ValueError):
+        opt.solve(np.zeros((4, n)))
     # Add the correct objective and constraints
     opt.setObjective(f)
     opt.setConstraints(lambda z, sz: jnp.asarray([0.1 - z[2], z[2] - 0.6]))
@@ -74,11 +79,6 @@ def test_GlobalSurrogate_RS():
     opt.setPenalty(L)
     opt.addAcquisition(acqu1, acqu2, acqu3)
     opt.setTrFunc(lambda x, r: 100)
-    # Try to solve with invalid inputs to test error handling
-    with pytest.raises(ValueError):
-        opt.solve(np.zeros((3, n-1)))
-    with pytest.raises(ValueError):
-        opt.solve(np.zeros((4, n)))
     # Solve the surrogate problem with GlobalSurrogate_RS, starting from the centroid
     x = np.zeros((3, n))
     x[:] = 0.5

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
               "parmoo.tests.libe_tests",
               "parmoo.tests.regression_tests"],
 
-    install_requires=["numpy", "scipy", "pyDOE", "pandas"],
+    install_requires=["jax", "numpy", "scipy", "pandas"],
 
     # If run tests through setup.py - downloads these but does not install
     tests_require=["pytest", "pytest-cov", "flake8"],


### PR DESCRIPTION
Don't save anything that's been jitted

-- this makes certain iteration tasks slightly slower but is required for working with libEnsemble, which regularly pickles the moop object and can't pickle jitted code