### PR TITLE
Error check cleanup

### DIFF
--- a/.github/config/custom-wordlist.txt
+++ b/.github/config/custom-wordlist.txt
@@ -208,6 +208,7 @@ globalGPS
 gradFunc
 grey
 hacky
+hashable
 html
 http
 https

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,23 @@ Below are the release notes for ParMOO.
 May reference issues on:
 https://github.com/parmoo/parmoo/issues
 
+Next Release
+------------
+
+:Date: TBD
+
+Summary TBD
+
+Major changes:
+
+ - TBD
+
+Minor changes:
+
+ - Replace complex error handling with external utilities to improve
+   readability and testability of code
+ - Flatten nested error handling logic wherever possible to reduce branch count
+
 Release 0.5.1
 -------------
 

--- a/parmoo/acquisitions/chebyshev.py
+++ b/parmoo/acquisitions/chebyshev.py
@@ -14,7 +14,7 @@ from jax import numpy as jnp
 import numpy as np
 import inspect
 from parmoo.acquisitions.acquisition_function import AcquisitionFunction
-from parmoo.utilities.error_checks import xerror
+from parmoo.utilities.error_checks import get_hp, xerror
 
 
 class UniformAugChebyshev(AcquisitionFunction):
@@ -52,41 +52,21 @@ class UniformAugChebyshev(AcquisitionFunction):
 
         """
 
-        # Check inputs
         xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
-        # Set the objective count
         self.o = o
-        # Set the design variable count
         self.n = np.size(lb)
-        # Set the bound constraints
         self.lb = lb
         self.ub = ub
-        # Initialize the weights array
         self.weights = np.zeros(o)
-        # Check hyperparameters
         self.eps = jnp.finfo(jnp.ones(1).dtype).eps
-        self.alpha = self.eps ** 0.25 / self.o
-        if 'alpha' in hyperparams.keys():
-            if isinstance(hyperparams['alpha'], float):
-                if hyperparams['alpha'] >= 0 and hyperparams['alpha'] <= 1:
-                    self.alpha = hyperparams['alpha']
-                else:
-                    raise ValueError("When present, hyperparams['alpha'] " +
-                                     "must be in the range [0, 1]")
-            else:
-                raise TypeError("When present, hyperparams['alpha'] " +
-                                "must be a float type")
-        # Check the hyperparameter dictionary for random generator
-        if 'np_random_gen' in hyperparams:
-            if isinstance(hyperparams['np_random_gen'], np.random.Generator):
-                self.np_rng = hyperparams['np_random_gen']
-            else:
-                raise TypeError("When present, hyperparams['np_random_gen'] "
-                                "must be an instance of the class "
-                                "numpy.random.Generator")
-        else:
-            self.np_rng = np.random.default_rng()
-        return
+        self.alpha = get_hp(
+                "alpha", hyperparams, float, lambda x: x >= 0 and x <= 1,
+                self.eps ** 0.25 / self.o
+        )
+        self.np_rng = get_hp(
+                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
+                np.random.default_rng()
+        )
 
     def useSD(self):
         """ Query whether this method uses uncertainties.
@@ -278,56 +258,26 @@ class FixedAugChebyshev(AcquisitionFunction):
 
         """
 
-        # Check inputs
         xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
-        # Set the objective count
         self.o = o
-        # Set the design variable count
         self.n = np.size(lb)
-        # Set the bound constraints
         self.lb = lb
         self.ub = ub
-        # Check the hyperparameter dictionary for random generator
-        if 'np_random_gen' in hyperparams:
-            if isinstance(hyperparams['np_random_gen'], np.random.Generator):
-                self.np_rng = hyperparams['np_random_gen']
-            else:
-                raise TypeError("When present, hyperparams['np_random_gen'] "
-                                "must be an instance of the class "
-                                "numpy.random.Generator")
-        else:
-            self.np_rng = np.random.default_rng()
-        # Check the hyperparams dictionary for weights
-        if 'weights' in hyperparams:
-            # If weights are provided, check that they are legal
-            if not isinstance(hyperparams['weights'], np.ndarray):
-                raise TypeError("when present, 'weights' must be a " +
-                                "numpy array")
-            else:
-                if hyperparams['weights'].size != self.o:
-                    raise ValueError("when present, 'weights' must " +
-                                     "have length o")
-                else:
-                    # Assign the weights
-                    self.weights = hyperparams['weights'].flatten()
-        else:
-            # If no weights provided, sample from the unit simplex
-            self.weights = -np.log(1.0 - self.np_rng.random(self.o))
-            self.weights = self.weights[:] / sum(self.weights[:])
-        # Check hyperparameters dictionary for alpha
         self.eps = jnp.finfo(jnp.ones(1).dtype).eps
-        self.alpha = self.eps ** 0.25 / self.o
-        if 'alpha' in hyperparams.keys():
-            if isinstance(hyperparams['alpha'], float):
-                if hyperparams['alpha'] >= 0 and hyperparams['alpha'] <= 1:
-                    self.alpha = hyperparams['alpha']
-                else:
-                    raise ValueError("When present, hyperparams['alpha'] " +
-                                     "must be in the range [0, 1]")
-            else:
-                raise TypeError("When present, hyperparams['alpha'] " +
-                                "must be a float type")
-        return
+        self.alpha = get_hp(
+                "alpha", hyperparams, float, lambda x: x >= 0 and x <= 1,
+                self.eps ** 0.25 / self.o
+        )
+        self.np_rng = get_hp(
+                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
+                np.random.default_rng()
+        )
+        default_weights = -np.log(1.0 - self.np_rng.random(self.o))
+        default_weights /= sum(default_weights)
+        self.weights = get_hp(
+                "weights", hyperparams, np.ndarray, lambda x: x.size == self.o,
+                default_weights
+        ).flatten()
 
     def useSD(self):
         """ Query whether this method uses uncertainties.

--- a/parmoo/acquisitions/chebyshev.py
+++ b/parmoo/acquisitions/chebyshev.py
@@ -64,8 +64,8 @@ class UniformAugChebyshev(AcquisitionFunction):
                 self.eps ** 0.25 / self.o
         )
         self.np_rng = get_hp(
-                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
-                np.random.default_rng()
+                "np_random_gen", hyperparams, np.random.Generator,
+                lambda x: True, np.random.default_rng()
         )
 
     def useSD(self):
@@ -269,8 +269,8 @@ class FixedAugChebyshev(AcquisitionFunction):
                 self.eps ** 0.25 / self.o
         )
         self.np_rng = get_hp(
-                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
-                np.random.default_rng()
+                "np_random_gen", hyperparams, np.random.Generator,
+                lambda x: True, np.random.default_rng()
         )
         default_weights = -np.log(1.0 - self.np_rng.random(self.o))
         default_weights /= sum(default_weights)

--- a/parmoo/acquisitions/epsilon_constraint.py
+++ b/parmoo/acquisitions/epsilon_constraint.py
@@ -60,8 +60,8 @@ class RandomConstraint(AcquisitionFunction):
         self.lb = lb
         self.eps = jnp.finfo(jnp.ones(1).dtype).eps
         self.np_rng = get_hp(
-                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
-                np.random.default_rng()
+                "np_random_gen", hyperparams, np.random.Generator,
+                lambda x: True, np.random.default_rng()
         )
 
     def useSD(self):
@@ -262,8 +262,8 @@ class EI_RandomConstraint(AcquisitionFunction):
                 "mc_sample_size", hyperparams, int, lambda x: x > 0, -1
         )
         self.np_rng = get_hp(
-                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
-                np.random.default_rng()
+                "np_random_gen", hyperparams, np.random.Generator,
+                lambda x: True, np.random.default_rng()
         )
 
     def useSD(self):

--- a/parmoo/acquisitions/epsilon_constraint.py
+++ b/parmoo/acquisitions/epsilon_constraint.py
@@ -13,7 +13,7 @@ import inspect
 from jax import numpy as jnp
 import numpy as np
 from parmoo.acquisitions.acquisition_function import AcquisitionFunction
-from parmoo.utilities.error_checks import xerror
+from parmoo.utilities.error_checks import get_hp, xerror
 from scipy import stats, integrate
 
 
@@ -51,28 +51,18 @@ class RandomConstraint(AcquisitionFunction):
 
         """
 
-        # Check inputs
         xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
         self.o = o
-        # Set the design variable count
         self.n = np.size(lb)
-        # Initialize the objective/design bounds
         self.f_ub = np.zeros(self.o)
         self.weights = np.zeros(self.o)
         self.ub = ub
         self.lb = lb
-        # Check the hyperparameter dictionary for random generator
-        if 'np_random_gen' in hyperparams:
-            if isinstance(hyperparams['np_random_gen'], np.random.Generator):
-                self.np_rng = hyperparams['np_random_gen']
-            else:
-                raise TypeError("When present, hyperparams['np_random_gen'] "
-                                "must be an instance of the class "
-                                "numpy.random.Generator")
-        else:
-            self.np_rng = np.random.default_rng()
         self.eps = jnp.finfo(jnp.ones(1).dtype).eps
-        return
+        self.np_rng = get_hp(
+                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
+                np.random.default_rng()
+        )
 
     def useSD(self):
         """ Query whether this method uses uncertainties.
@@ -260,33 +250,21 @@ class EI_RandomConstraint(AcquisitionFunction):
 
         """
 
-        # Check inputs
         xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
         self.o = o
-        # Set the design variable count
         self.n = np.size(lb)
-        # Initialize the objective/design bounds
         self.f_ub = np.zeros(self.o)
         self.weights = np.zeros(self.o)
         self.ub = ub
         self.lb = lb
-        # Check the hyperparameter dictionary for custom MC sample size
-        if 'mc_sample_size' in hyperparams.keys():
-            self.sample_size = hyperparams['mc_sample_size']
-        else:
-            self.sample_size = None
-        # Check the hyperparameter dictionary for random generator
-        if 'np_random_gen' in hyperparams:
-            if isinstance(hyperparams['np_random_gen'], np.random.Generator):
-                self.np_rng = hyperparams['np_random_gen']
-            else:
-                raise TypeError("When present, hyperparams['np_random_gen'] "
-                                "must be an instance of the class "
-                                "numpy.random.Generator")
-        else:
-            self.np_rng = np.random.default_rng()
         self.eps = jnp.finfo(jnp.ones(1).dtype).eps
-        return
+        self.sample_size = get_hp(
+                "mc_sample_size", hyperparams, int, lambda x: x > 0, -1
+        )
+        self.np_rng = get_hp(
+                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
+                np.random.default_rng()
+        )
 
     def useSD(self):
         """ Query whether this method uses uncertainties.
@@ -464,7 +442,7 @@ class EI_RandomConstraint(AcquisitionFunction):
         # If there is at least one feasible point and the number of sim outs
         # is greater than 1, then evaluate the EI over fi* via MC integration
         else:
-            if self.sample_size is None:
+            if self.sample_size < 0:
                 self.sample_size = int(10 * s_vals_mean.size ** 2)
             # Construct the distribution for sampling
             s_cov = stats.Covariance.from_diagonal(s_vals_sd)

--- a/parmoo/acquisitions/weighted_sum.py
+++ b/parmoo/acquisitions/weighted_sum.py
@@ -14,7 +14,7 @@ from jax import numpy as jnp
 import numpy as np
 import inspect
 from parmoo.acquisitions.acquisition_function import AcquisitionFunction
-from parmoo.utilities.error_checks import xerror
+from parmoo.utilities.error_checks import get_hp, xerror
 
 
 class UniformWeights(AcquisitionFunction):
@@ -49,29 +49,17 @@ class UniformWeights(AcquisitionFunction):
 
         """
 
-        # Check inputs
         xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
-        # Set the objective count
         self.o = o
-        # Set the design variable count
         self.n = np.size(lb)
-        # Set the bound constraints
         self.lb = lb
         self.ub = ub
-        # Initialize the weights array
         self.weights = np.zeros(o)
-        # Check the hyperparams dictionary for a generator
-        if 'np_random_gen' in hyperparams:
-            if isinstance(hyperparams['np_random_gen'], np.random.Generator):
-                self.np_rng = hyperparams['np_random_gen']
-            else:
-                raise TypeError("When present, hyperparams['np_random_gen'] "
-                                "must be an instance of the class "
-                                "numpy.random.Generator")
-        else:
-            self.np_rng = np.random.default_rng()
         self.eps = jnp.finfo(jnp.ones(1).dtype).eps
-        return
+        self.np_rng = get_hp(
+                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
+                np.random.default_rng()
+        )
 
     def useSD(self):
         """ Query whether this method uses uncertainties.
@@ -228,44 +216,22 @@ class FixedWeights(AcquisitionFunction):
 
         """
 
-        # Check inputs
         xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
-        # Set the objective count
         self.o = o
-        # Set the design variable count
         self.n = np.size(lb)
-        # Set the bound constraints
         self.lb = lb
         self.ub = ub
-        # Check the hyperparams dictionary for a generator
-        if 'np_random_gen' in hyperparams:
-            if isinstance(hyperparams['np_random_gen'], np.random.Generator):
-                self.np_rng = hyperparams['np_random_gen']
-            else:
-                raise TypeError("When present, hyperparams['np_random_gen'] "
-                                "must be an instance of the class "
-                                "numpy.random.Generator")
-        else:
-            self.np_rng = np.random.default_rng()
-        # Check the hyperparams dictionary for weights
         self.eps = jnp.finfo(jnp.ones(1).dtype).eps
-        if 'weights' in hyperparams:
-            # If weights are provided, check that they are legal
-            if not isinstance(hyperparams['weights'], np.ndarray):
-                raise TypeError("when present, 'weights' must be a " +
-                                "numpy array")
-            else:
-                if hyperparams['weights'].size != self.o:
-                    raise ValueError("when present, 'weights' must " +
-                                     "have length o")
-                else:
-                    # Assign the weights
-                    self.weights = hyperparams['weights'].flatten()
-        else:
-            # If no weights provided, sample from the unit simplex
-            self.weights = -np.log(1.0 - self.np_rng.random(self.o))
-            self.weights = self.weights[:] / sum(self.weights[:])
-        return
+        self.np_rng = get_hp(
+                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
+                np.random.default_rng()
+        )
+        default_weights = -np.log(1.0 - self.np_rng.random(self.o))
+        default_weights /= sum(default_weights)
+        self.weights = get_hp(
+                "weights", hyperparams, np.ndarray, lambda x: x.size == self.o,
+                default_weights
+        ).flatten()
 
     def useSD(self):
         """ Query whether this method uses uncertainties.

--- a/parmoo/acquisitions/weighted_sum.py
+++ b/parmoo/acquisitions/weighted_sum.py
@@ -57,8 +57,8 @@ class UniformWeights(AcquisitionFunction):
         self.weights = np.zeros(o)
         self.eps = jnp.finfo(jnp.ones(1).dtype).eps
         self.np_rng = get_hp(
-                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
-                np.random.default_rng()
+                "np_random_gen", hyperparams, np.random.Generator,
+                lambda x: True, np.random.default_rng()
         )
 
     def useSD(self):
@@ -223,8 +223,8 @@ class FixedWeights(AcquisitionFunction):
         self.ub = ub
         self.eps = jnp.finfo(jnp.ones(1).dtype).eps
         self.np_rng = get_hp(
-                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
-                np.random.default_rng()
+                "np_random_gen", hyperparams, np.random.Generator,
+                lambda x: True, np.random.default_rng()
         )
         default_weights = -np.log(1.0 - self.np_rng.random(self.o))
         default_weights /= sum(default_weights)

--- a/parmoo/core/moop_base.py
+++ b/parmoo/core/moop_base.py
@@ -172,10 +172,10 @@ class MOOP_base(ABC):
         self.acq_tmp, self.search_tmp, self.sur_tmp = [], [], []
         self.acq_hp, self.sim_hp = [], []
         self.optimizer, self.opt_tmp = None, None
-        self.opt_hp = {}
         # Initialize the database
         self.database = NumpyDatabase(hyperparams)
         # Set up the surrogate optimizer and its hyperparameters
+        self.opt_hp = {}
         if hyperparams is not None:
             if isinstance(hyperparams, dict):
                 self.opt_hp = hyperparams

--- a/parmoo/core/moop_checks.py
+++ b/parmoo/core/moop_checks.py
@@ -8,6 +8,7 @@ They are:
 import numpy as np
 from parmoo.searches.global_search import GlobalSearch
 from parmoo.surrogates.surrogate_function import SurrogateFunction
+from parmoo.utilities.error_checks import get_hp
 import inspect
 
 
@@ -58,149 +59,98 @@ def check_sims(n, *args):
 
     """
 
-    # Iterate through args to check each sim
-    s = 0
-    m = 0
-    for arg in args:
-        if isinstance(arg, dict):
-            if 'name' in arg:
-                if not isinstance(arg['name'], str):
-                    raise TypeError("sims[" + str(s) + "]['name']"
-                                    + " must be a string when present")
-            # Check the number of sim outputs
-            if 'm' in arg:
-                if isinstance(arg['m'], int):
-                    if arg['m'] > 0:
-                        m = arg['m']
-                    else:
-                        raise ValueError("sims[" + str(s) + "]['m']"
-                                         + " must be greater than zero")
-                else:
-                    raise TypeError("sims[" + str(s) + "] : 'm'"
-                                    + " must be an int")
-            else:
-                raise AttributeError("sims[" + str(s)
-                                     + "] is missing the key 'm'")
-            # Get the hyperparameter dict
-            if 'hyperparams' in arg:
-                if not isinstance(arg['hyperparams'], dict):
-                    raise TypeError("sims[" + str(s)
-                                    + "]: 'hyperparams'"
-                                    + " key must be a dict when present")
-            # Check the search technique
-            if 'search' in arg:
-                try:
-                    assert isinstance(
-                        arg['search'](m, np.zeros(n), np.ones(n), {}),
-                        GlobalSearch
-                    )
-                except BaseException:
-                    raise TypeError(
-                        f"sims[{s}]['search'] must be a derivative of "
-                        "the GlobalSearch abstract class"
-                    )
-            else:
-                raise AttributeError(f"sims[{s}] is missing the key 'search'")
-            # Check the des_tol, if present
-            if 'des_tol' in arg:
-                if isinstance(arg['des_tol'], float):
-                    if arg['des_tol'] <= 0.0:
-                        raise ValueError(
-                            f"sims[{s}]['des_tol'] must be greater than 0"
-                        )
-                else:
-                    raise TypeError(f"sims[{s}]['des_tol'] must be a float")
-            # Get the surrogate function
-            if 'surrogate' in arg:
-                try:
-                    if not isinstance(arg['surrogate'](m, np.zeros(n),
-                                                       np.ones(n), {}),
-                                      SurrogateFunction):
-                        raise TypeError("sims[" + str(s) + "] :"
-                                        + " 'surrogate' must be a"
-                                        + " derivative of the"
-                                        + " SurrogateFunction abstract"
-                                        + " class")
-                except BaseException:
-                    raise TypeError("sims[" + str(s)
-                                    + "]['surrogate']"
-                                    + " must be a derivative of the"
-                                    + " SurrogateFunction abstract class")
-            else:
-                raise AttributeError("sims[" + str(s) + "] is missing"
-                                     + " the key 'surrogate'")
-            # Get the simulation function
-            if 'sim_func' in arg:
-                if callable(arg['sim_func']):
-                    if len(inspect.signature(arg['sim_func']).parameters) \
-                       != 1 and \
-                       len(inspect.signature(arg['sim_func']).parameters) \
-                       != 2:
-                        raise ValueError("sims[" + str(s) + "]["
-                                         + "'sim_func'] must accept"
-                                         + " one or two inputs")
-                else:
-                    raise TypeError("sims[" + str(s)
-                                    + "]['sim_func']"
-                                    + " must be callable")
-            else:
-                raise AttributeError("sims[" + str(s) + "] is missing"
-                                     + " the key 'sim_func'")
-            # Get the starting database, if present
-            if 'sim_db' in arg:
-                if isinstance(arg['sim_db'], dict):
-                    if 'x_vals' in arg['sim_db'] and \
-                       's_vals' in arg['sim_db']:
-                        try:
-                            # Cast arg['sim_db'] contents to np.ndarrays
-                            xvals = np.asarray(arg['sim_db']['x_vals'])
-                            svals = np.asarray(arg['sim_db']['s_vals'],
-                                               dtype=np.float64)
-                        except BaseException:
-                            raise TypeError("sims[" + str(s)
-                                            + "]['sim_db']"
-                                            + "['x_vals'] or sims["
-                                            + str(s) + "]['sim_db']"
-                                            + "['s_vals'] could not be"
-                                            + " cast as a numpy array")
-                        # Check the resulting dimensions
-                        if xvals.size != 0 and svals.size != 0:
-                            if xvals.ndim > 1:
-                                if xvals.shape[1] != n:
-                                    raise ValueError("sims[" + str(s)
-                                                     + "]['sim_db']['x_vals']"
-                                                     + " does not have"
-                                                     + " n cols per row")
-                                elif xvals.shape[0] != svals.shape[0]:
-                                    raise ValueError("sims[" + str(s)
-                                                     + "]['sim_db']['x_vals']"
-                                                     + " does not have same"
-                                                     + " number of rows as"
-                                                     + " sims[" + str(s)
-                                                     + "]['sim_db']['s_vals']")
-                            if svals.shape[1] != m:
-                                raise ValueError("sims[" + str(s)
-                                                 + "]['sim_db']['s_vals']"
-                                                 + " does not have"
-                                                 + " sims[" + str(s)
-                                                 + "]['m'] cols per row")
-                        elif xvals.size != svals.size:
-                            raise ValueError("sims[" + str(s)
-                                             + "]['sim_db']['x_vals']"
-                                             + " cannot be empty when"
-                                             + " sims[" + str(s)
-                                             + "]['sim_db']['s_vals']"
-                                             + " is nonempty, and vice"
-                                             + " versa")
-                    elif 'x_vals' in arg['sim_db'] or \
-                         's_vals' in arg['sim_db']:
-                        raise AttributeError("sims[" + str(s) + "] cannot"
-                                             + " contain a sim_db with"
-                                             + " 'x_vals' but not 's_vals'"
-                                             + " or vice versa")
-                else:
-                    raise TypeError("sims[" + str(s) + "]['sim_db']"
-                                    + " must be a dict")
-            s += 1
-        else:
+    for s, arg in enumerate(args):
+        if not isinstance(arg, dict):
             raise TypeError("sims[" + str(s) + "] is not a dict")
+        if "name" in arg and not isinstance(arg["name"], str):
+            raise TypeError(
+                    f"sims[{s}]['name'] must be a string when present"
+            )
+        if "m" not in arg:
+            raise KeyError(f"sims[{s}] is missing the key 'm'")
+        if not isinstance(arg["m"], int):
+            raise TypeError(f"sims[{s}] : 'm' must be an int")
+        if arg["m"] <= 0:
+            raise ValueError(f"sims[{s}]['m'] must be greater than zero")
+        m = arg["m"]
+        if "hyperparams" in arg and not isinstance(arg["hyperparams"], dict):
+            raise TypeError(
+                    f"sims[{s}]: 'hyperparams' key must be a dict when present"
+            )
+        if "search" not in arg:
+            raise KeyError(f"sims[{s}] is missing the key 'search'")
+        try:
+            assert isinstance(
+                arg['search'](m, np.zeros(n), np.ones(n), {}), GlobalSearch
+            )
+        except BaseException:
+            raise TypeError(
+                f"sims[{s}]['search'] must be a derivative of the "
+                "GlobalSearch abstract class"
+            )
+        if "surrogate" not in arg:
+            raise KeyError(f"sims[{s}] is missing the key 'surrogate'")
+        try:
+            assert isinstance(
+                arg["surrogate"](m, np.zeros(n), np.ones(n), {}),
+                SurrogateFunction
+            )
+        except BaseException:
+            raise TypeError(
+                    f"sims[{s}]['surrogate'] must be a derivative of the "
+                    "SurrogateFunction abstract class"
+            )
+        if "sim_func" not in arg:
+            raise KeyError(f"sims[{s}] is missing the key 'sim_func'")
+        if not callable(arg["sim_func"]):
+            raise TypeError("sims[{s}]['sim_func'] must be callable")
+        if len(inspect.signature(arg['sim_func']).parameters) not in [1, 2]:
+            raise ValueError("sims[{s}]['sim_func'] must accept 1 or 2 inputs")
+        if "des_tol" in arg:
+            _ = get_hp("des_tol", arg, float, lambda x: x > 0.0, 1.0e-8)
+
+        if "sim_db" not in arg:
+            continue
+        if not isinstance(arg["sim_db"], dict):
+            raise TypeError(f"sims[{s}]['sim_db'] must be a dict")
+        if ("x_vals" in arg["sim_db"]) != ("s_vals" in arg["sim_db"]):
+            raise KeyError(
+                    f"sims[{s}] cannot contain a sim_db with 'x_vals' but "
+                    "not 's_vals' or vice versa"
+            )
+
+        if "x_vals" not in arg["sim_db"]:
+            continue
+
+        try:
+            xvals = np.asarray(arg['sim_db']['x_vals'])
+            svals = np.asarray(arg['sim_db']['s_vals'], dtype=np.float64)
+        except BaseException:
+            raise TypeError(
+                    f"Either sims[{s}]['sim_db']['x_vals'] or "
+                    f"sims[{s}]['sim_db']['s_vals'] could not be cast as a "
+                    "numpy array"
+            )
+        if (xvals.size == 0) != (svals.size == 0):
+            raise ValueError(
+                    f"sims[{s}]['sim_db']['x_vals'] cannot be empty "
+                    f"when sims[{s}]['sim_db']['s_vals'] is nonempty, "
+                    "and vice versa"
+            )
+        if xvals.size == 0:
+            continue
+        if xvals.ndim < 2 or xvals.shape[1] != n:
+            raise ValueError(
+                    f"sims[{s}]['sim_db']['x_vals'] does not have "
+                    f"{n} columns per row"
+            )
+        if xvals.shape[0] != svals.shape[0]:
+            raise ValueError(
+                    f"sims[{s}]['sim_db']['x_vals'] does not have the same"
+                    f" number of rows as sims[{s}]['sim_db']['s_vals']"
+            )
+        if svals.ndim < 2 or svals.shape[1] != m:
+            raise ValueError(
+                    f"sims[{s}]['sim_db']['s_vals'] does not have "
+                    f"sims[{s}]['m'] columns per row"
+            )

--- a/parmoo/embeddings/default_embedders.py
+++ b/parmoo/embeddings/default_embedders.py
@@ -15,6 +15,7 @@ This includes the following classes:
 from jax import numpy as jnp
 import numpy as np
 from parmoo.embeddings.embedder import Embedder
+from parmoo.utilities.error_checks import get_hp
 
 
 class ContinuousEmbedder(Embedder):
@@ -43,45 +44,30 @@ class ContinuousEmbedder(Embedder):
 
         """
 
-        # Error handling and extracting input bounds
-        if isinstance(settings, dict):
-            if 'lb' in settings:
-                try:
-                    lb = float(settings['lb'])
-                except BaseException:
-                    raise TypeError("lower bound must contain a float or int")
-            else:
-                raise KeyError("'lb' is a required key for continuous "
-                               "design variables")
-            if 'ub' in settings:
-                try:
-                    ub = float(settings['ub'])
-                except BaseException:
-                    raise TypeError("upper bound must contain a float or int")
-            else:
-                raise KeyError("'ub' is a required key for continuous "
-                               "design variables")
-            if 'des_tol' in settings:
-                des_tol = settings['des_tol']
-                if not isinstance(des_tol, float):
-                    raise TypeError("design tolerance must be a float type")
-                if des_tol <= 0:
-                    raise ValueError("design tolerance must be strictly "
-                                     "greater than 0")
-            else:
-                eps = jnp.finfo(jnp.zeros(1).dtype).eps
-                des_tol = eps * max(ub - lb, np.sqrt(eps))
-            if lb + des_tol > ub:
-                raise ValueError("lower bound must be strictly less than "
-                                 "upper bound for all design variables "
-                                 "up to the design tolerance")
-        else:
-            raise TypeError("settings must be a dictionary")
-        # Calculate the embedding as a sequence of matrix operations
+        tmp_settings = {}
+        try:
+            tmp_settings["lb"] = float(settings["lb"])
+            tmp_settings["ub"] = float(settings["ub"])
+        except KeyError:
+            raise KeyError(
+                    "'lb' and 'ub' are required keys for continuous design "
+                    "variables"
+            )
+        lb = get_hp("lb", tmp_settings, float, lambda x: True, None)
+        ub = get_hp("ub", tmp_settings, float, lambda x: True, None)
+        eps = jnp.finfo(jnp.zeros(1).dtype).eps
+        des_tol = get_hp(
+            "des_tol", settings, float, lambda x: x > 0,
+            eps * max(ub - lb, np.sqrt(eps))
+        )
+        if lb + des_tol > ub:
+            raise ValueError(
+                    "lower bound must be strictly less than upper bound for "
+                    "all design variables up to the design tolerance"
+            )
         self.scale = jnp.ones(1) * (ub - lb)
         self.shift = jnp.ones(1) * lb
         self.scaled_des_tol = np.ones(1) * des_tol / self.scale
-        return
 
     def getLatentDesTols(self):
         """ Get the design tolerances along each dimension of the embedding.
@@ -206,43 +192,14 @@ class IntegerEmbedder(Embedder):
                  * 'ub' (float or int, required): This specifies the upper
                    bound for the design variable. This value must be strictly
                    greater than 'lb' (above) up to the tolerance (below).
-                 * 'des_tol' (float, optional): This specifies the design
-                   tolerance for this variable, i.e., the minimum spacing
-                   before two design values are considered equivalent up to
-                   measurement error. If not specified, the
-                   default value is eps * max(ub - lb, sqrt(eps)), where
-                   eps is the unit roundoff.
 
         """
 
-        # Error handling and extracting input bounds
-        if isinstance(settings, dict):
-            if 'lb' in settings:
-                try:
-                    lb = float(settings['lb'])
-                except BaseException:
-                    raise TypeError("lower bound must contain a float or int")
-            else:
-                raise KeyError("'lb' is a required key for continuous "
-                               "design variables")
-            if 'ub' in settings:
-                try:
-                    ub = float(settings['ub'])
-                except BaseException:
-                    raise TypeError("upper bound must contain a float or int")
-            else:
-                raise KeyError("'ub' is a required key for continuous "
-                               "design variables")
-            if lb >= ub:
-                raise ValueError("lower bound must be strictly less than "
-                                 "upper bound for all design variables ")
-        else:
-            raise TypeError("settings must be a dictionary")
-        # Calculate the embedding as a sequence of matrix operations
+        lb = get_hp("lb", settings, int, lambda x: True, None)
+        ub = get_hp("ub", settings, int, lambda x: x > lb, None)
         self.scale = jnp.ones(1) * (ub - lb)
         self.shift = jnp.ones(1) * lb
         self.scaled_des_tol = np.ones(1) * 0.5 / self.scale
-        return
 
     def getLatentDesTols(self):
         """ Get the design tolerances along each dimension of the embedding.
@@ -368,38 +325,28 @@ class CategoricalEmbedder(Embedder):
 
         """
 
-        # Error handling and extracting input types
-        if isinstance(settings, dict) and 'levels' in settings:
-            levels = settings['levels']
-            if isinstance(levels, int):
-                if levels < 2:
-                    raise ValueError("a categorical variable must "
-                                     "have at least 2 levels")
-                n_lvls = levels
-                self.alabels = jnp.array([i for i in range(levels)], dtype=int)
+        n_lvls = 0
+        try:
+            n_lvls = get_hp("levels", settings, int, lambda x: x >= 2, None)
+            self.alabels = jnp.array([i for i in range(n_lvls)], dtype=int)
+            self.in_type = 'i4'
+        except BaseException:
+            levels = get_hp(
+                    "levels", settings, list, lambda x: len(x) >= 2, None
+            )
+            n_lvls = len(levels)
+            if not (
+                    all([isinstance(li, int) for li in levels]) or
+                    all([isinstance(li, str) for li in levels])
+            ):
+                raise TypeError("all levels of categorical variable "
+                                "must have the same type (int or str)")
+            try:
+                self.alabels = jnp.array(levels)
                 self.in_type = 'i4'
-            elif isinstance(levels, list):
-                n_lvls = len(levels)
-                if n_lvls < 2:
-                    raise ValueError("a categorical variable must "
-                                     "have at least 2 levels")
-                if not (all([isinstance(li, int) for li in levels]) or
-                        all([isinstance(li, str) for li in levels])):
-                    raise TypeError("all levels of categorical variable "
-                                    "must have the same type (int or str)")
-                try:
-                    self.alabels = jnp.array(levels)
-                    self.in_type = 'i4'
-                except TypeError:
-                    self.alabels = np.array(levels)
-                    self.in_type = 'U25'
-            else:
-                raise TypeError("settings['levels'] must be an int or list")
-        elif isinstance(settings, dict):
-            raise KeyError("'levels' key is missing for categorical variable")
-        else:
-            raise TypeError("settings must be a dictionary")
-        # Calculate the embedding as a sequence of matrix operations via SVD
+            except TypeError:
+                self.alabels = np.array(levels)
+                self.in_type = 'U25'
         n = n_lvls - 1
         self.cent = jnp.ones(n_lvls) / n_lvls
         u, sigma, vT = jnp.linalg.svd(jnp.eye(n_lvls) - self.cent)
@@ -409,7 +356,6 @@ class CategoricalEmbedder(Embedder):
         self.des_tol = np.sqrt(0.5) / self.scale
         self.zeros = jnp.zeros(n_lvls)
         self.ones = jnp.ones(n_lvls)
-        return
 
     def getLatentDesTols(self):
         """ Get the design tolerances along each dimension of the embedding.
@@ -545,41 +491,27 @@ class IdentityEmbedder(Embedder):
 
         """
 
-        # Error handling and extracting input bounds
-        if isinstance(settings, dict):
-            if 'lb' in settings:
-                try:
-                    self.lb = float(settings['lb'])
-                except BaseException:
-                    raise TypeError("lower bound must contain a float or int")
-            else:
-                raise KeyError("'lb' is a required key for continuous "
-                               "design variables")
-            if 'ub' in settings:
-                try:
-                    self.ub = float(settings['ub'])
-                except BaseException:
-                    raise TypeError("upper bound must contain a float or int")
-            else:
-                raise KeyError("'ub' is a required key for continuous "
-                               "design variables")
-            if 'des_tol' in settings:
-                self.des_tol = settings['des_tol']
-                if not isinstance(self.des_tol, float):
-                    raise TypeError("design tolerance must be a float type")
-                if self.des_tol <= 0:
-                    raise ValueError("design tolerance must be strictly "
-                                     "greater than 0")
-            else:
-                eps = jnp.finfo(jnp.zeros(1).dtype).eps
-                self.des_tol = eps * max(self.ub - self.lb, np.sqrt(eps))
-            if self.lb + self.des_tol > self.ub:
-                raise ValueError("lower bound must be strictly less than "
-                                 "upper bound for all design variables "
-                                 "up to the design tolerance")
-        else:
-            raise TypeError("settings must be a dictionary")
-        return
+        tmp_settings = {}
+        try:
+            tmp_settings["lb"] = float(settings["lb"])
+            tmp_settings["ub"] = float(settings["ub"])
+        except KeyError:
+            raise KeyError(
+                    "'lb' and 'ub' are required keys for continuous design "
+                    "variables"
+            )
+        self.lb = get_hp("lb", tmp_settings, float, lambda x: True, None)
+        self.ub = get_hp("ub", tmp_settings, float, lambda x: True, None)
+        eps = jnp.finfo(jnp.zeros(1).dtype).eps
+        self.des_tol = get_hp(
+                "des_tol", settings, float, lambda x: x > 0,
+                eps * max(self.ub - self.lb, np.sqrt(eps))
+        )
+        if self.lb + self.des_tol > self.ub:
+            raise ValueError(
+                    "lower bound must be strictly less than upper bound for "
+                    "all design variables up to the design tolerance"
+            )
 
     def getLatentDesTols(self):
         """ Get the design tolerances along each dimension of the embedding.

--- a/parmoo/optimizers/lbfgsb.py
+++ b/parmoo/optimizers/lbfgsb.py
@@ -19,6 +19,7 @@ from jax import numpy as jnp
 import numpy as np
 from parmoo.optimizers.surrogate_optimizer import SurrogateOptimizer
 from parmoo.utilities.error_checks import xerror
+from parmoo.utilities.moop_utils import get_hp
 config.update("jax_enable_x64", True)  # scipy.optimize.lbfgsb requires 64-bit
 
 
@@ -61,50 +62,23 @@ class GlobalSurrogate_BFGS(SurrogateOptimizer):
 
         """
 
-        # Check inputs
         xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
         self.n = lb.size
         self.bounds = np.zeros((self.n, 2))
         self.bounds[:, 0] = lb
         self.bounds[:, 1] = ub
         self.mu = np.sqrt(jnp.finfo(jnp.ones(1).dtype).eps)
-        # Check that the contents of hyperparams is legal
-        if 'opt_restarts' in hyperparams:
-            if isinstance(hyperparams['opt_restarts'], int):
-                if hyperparams['opt_restarts'] < 1:
-                    raise ValueError("hyperparams['opt_restarts'] "
-                                     "must be positive")
-                else:
-                    self.restarts = hyperparams['opt_restarts']
-            else:
-                raise TypeError("hyperparams['opt_restarts'] "
-                                "must be an integer")
-        else:
-            self.restarts = self.n + 1
-        if 'opt_budget' in hyperparams:
-            if isinstance(hyperparams['opt_budget'], int):
-                if hyperparams['opt_budget'] < 1:
-                    raise ValueError("hyperparams['opt_budget'] "
-                                     "must be positive")
-                else:
-                    self.budget = hyperparams['opt_budget']
-            else:
-                raise TypeError("hyperparams['opt_budget'] "
-                                "must be an integer")
-        else:
-            self.budget = 100
-        # Check the hyperparameter dictionary for random generator
-        if 'np_random_gen' in hyperparams:
-            if isinstance(hyperparams['np_random_gen'], np.random.Generator):
-                self.np_rng = hyperparams['np_random_gen']
-            else:
-                raise TypeError("When present, hyperparams['np_random_gen'] "
-                                "must be an instance of the class "
-                                "numpy.random.Generator")
-        else:
-            self.np_rng = np.random.default_rng()
+        self.restarts = get_hp(
+            "opt_restarts", hyperparams, int, lambda x: x >= 1, self.n + 1
+        )
+        self.budget = get_hp(
+            "opt_budget", hyperparams, int, lambda x: x >= 1, 100
+        )
+        self.np_rng = get_hp(
+            "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
+            np.random.default_rng()
+        )
         self.acquisitions = []
-        return
 
     def solve(self, x):
         """ Solve the surrogate problem using L-BFGS-B.
@@ -245,66 +219,30 @@ class LocalSurrogate_BFGS(SurrogateOptimizer):
 
         """
 
-        # Check inputs
         xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
         self.n = lb.size
         self.bounds = np.zeros((self.n, 2))
         self.bounds[:, 0] = lb
         self.bounds[:, 1] = ub
-        # Check that the contents of hyperparams is legal
-        if 'opt_budget' in hyperparams:
-            if isinstance(hyperparams['opt_budget'], int):
-                if hyperparams['opt_budget'] < 1:
-                    raise ValueError("hyperparams['opt_budget'] "
-                                     "must be positive")
-                else:
-                    self.budget = hyperparams['opt_budget']
-            else:
-                raise TypeError("hyperparams['opt_budget'] "
-                                "must be an integer")
-        else:
-            self.budget = 500
-        # Check that the contents of hyperparams is legal
-        if 'opt_restarts' in hyperparams:
-            if isinstance(hyperparams['opt_restarts'], int):
-                if hyperparams['opt_restarts'] < 1:
-                    raise ValueError("hyperparams['opt_restarts'] "
-                                     "must be positive")
-                else:
-                    self.restarts = hyperparams['opt_restarts']
-            else:
-                raise TypeError("hyperparams['opt_restarts'] "
-                                "must be an integer")
-        else:
-            self.restarts = 2
         self.mu = np.sqrt(jnp.finfo(jnp.ones(1).dtype).eps)
-        if 'des_tols' in hyperparams:
-            if isinstance(hyperparams['des_tols'], np.ndarray):
-                if hyperparams['des_tols'].size != self.n:
-                    raise ValueError("the length of hyperparpams['des_tols']"
-                                     " must match the length of lb and ub")
-                if not np.all(hyperparams['des_tols']):
-                    raise ValueError("all entries in hyperparams['des_tols']"
-                                     " must be greater than 0")
-            else:
-                raise TypeError("hyperparams['des_tols'] must be an array.")
-            self.des_tols = np.asarray(hyperparams['des_tols'])
-        else:
-            self.des_tols = (np.ones(self.n) * self.mu)
-        # Check the hyperparameter dictionary for random generator
-        if 'np_random_gen' in hyperparams:
-            if isinstance(hyperparams['np_random_gen'], np.random.Generator):
-                self.np_rng = hyperparams['np_random_gen']
-            else:
-                raise TypeError("When present, hyperparams['np_random_gen'] "
-                                "must be an instance of the class "
-                                "numpy.random.Generator")
-        else:
-            self.np_rng = np.random.default_rng()
+        self.restarts = get_hp(
+            "opt_restarts", hyperparams, int, lambda x: x >= 1, 2
+        )
+        self.budget = get_hp(
+            "opt_budget", hyperparams, int, lambda x: x >= 1, 500
+        )
+        self.des_tols = get_hp(
+            "des_tols", hyperparams, np.ndarray,
+            lambda x: x.size == self.n and np.all(x),
+            np.ones(self.n) * self.mu
+        )
+        self.np_rng = get_hp(
+            "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
+            np.random.default_rng()
+        )
         self.acquisitions = []
         self.prev_centers = []
         self.targets = []
-        return
 
     def __checkTR(self, center):
         """ Check the recommended trust region for a new center. """
@@ -339,7 +277,6 @@ class LocalSurrogate_BFGS(SurrogateOptimizer):
                 self.prev_centers.append([ci, ri])
         # Reset the list of targets for next iteration
         self.targets = []
-        return
 
     def returnResults(self, x, fx, sx, sdx):
         """ Collect the results of a function evaluation.
@@ -362,7 +299,6 @@ class LocalSurrogate_BFGS(SurrogateOptimizer):
             # Remove any targets that have been "hit"
             if fxj < ti[2]:
                 del self.targets[i]
-        return
 
     def solve(self, x):
         """ Solve the surrogate problem using L-BFGS-B.
@@ -501,7 +437,6 @@ class LocalSurrogate_BFGS(SurrogateOptimizer):
         # Save file
         with open(filename, 'w') as fp:
             json.dump(bfgs_state, fp)
-        return
 
     def load(self, filename):
         """ Reload important data into this class after a previous save.
@@ -530,6 +465,6 @@ class LocalSurrogate_BFGS(SurrogateOptimizer):
             self.prev_centers.append([np.array(ci), np.array(ri)])
         self.targets = []
         for ti in bfgs_state['targets']:
-            self.targets.append([np.array(ti[0]),
-                                 np.array(ti[1]), ti[2], ti[3]])
-        return
+            self.targets.append(
+                [np.array(ti[0]), np.array(ti[1]), ti[2], ti[3]]
+            )

--- a/parmoo/optimizers/lbfgsb.py
+++ b/parmoo/optimizers/lbfgsb.py
@@ -18,8 +18,7 @@ import jax
 from jax import numpy as jnp
 import numpy as np
 from parmoo.optimizers.surrogate_optimizer import SurrogateOptimizer
-from parmoo.utilities.error_checks import xerror
-from parmoo.utilities.moop_utils import get_hp
+from parmoo.utilities.error_checks import get_hp, xerror
 config.update("jax_enable_x64", True)  # scipy.optimize.lbfgsb requires 64-bit
 
 
@@ -68,6 +67,7 @@ class GlobalSurrogate_BFGS(SurrogateOptimizer):
         self.bounds[:, 0] = lb
         self.bounds[:, 1] = ub
         self.mu = np.sqrt(jnp.finfo(jnp.ones(1).dtype).eps)
+        self.acquisitions = []
         self.restarts = get_hp(
             "opt_restarts", hyperparams, int, lambda x: x >= 1, self.n + 1
         )
@@ -78,7 +78,6 @@ class GlobalSurrogate_BFGS(SurrogateOptimizer):
             "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
             np.random.default_rng()
         )
-        self.acquisitions = []
 
     def solve(self, x):
         """ Solve the surrogate problem using L-BFGS-B.
@@ -225,6 +224,9 @@ class LocalSurrogate_BFGS(SurrogateOptimizer):
         self.bounds[:, 0] = lb
         self.bounds[:, 1] = ub
         self.mu = np.sqrt(jnp.finfo(jnp.ones(1).dtype).eps)
+        self.acquisitions = []
+        self.prev_centers = []
+        self.targets = []
         self.restarts = get_hp(
             "opt_restarts", hyperparams, int, lambda x: x >= 1, 2
         )
@@ -240,9 +242,6 @@ class LocalSurrogate_BFGS(SurrogateOptimizer):
             "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
             np.random.default_rng()
         )
-        self.acquisitions = []
-        self.prev_centers = []
-        self.targets = []
 
     def __checkTR(self, center):
         """ Check the recommended trust region for a new center. """

--- a/parmoo/optimizers/pattern_search.py
+++ b/parmoo/optimizers/pattern_search.py
@@ -18,7 +18,7 @@ import jax
 from jax import numpy as jnp
 import numpy as np
 from parmoo.optimizers.surrogate_optimizer import SurrogateOptimizer
-from parmoo.utilities.error_checks import xerror
+from parmoo.utilities.error_checks import get_hp, xerror
 from scipy.stats.qmc import LatinHypercube
 
 
@@ -62,79 +62,33 @@ class LocalSurrogate_PS(SurrogateOptimizer):
 
         """
 
-        # Check inputs
         xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
         self.n = lb.size
         self.lb = lb
         self.ub = ub
         self.q_ind = 0
-        # Check that the contents of hyperparams are legal
-        if 'opt_restarts' in hyperparams:
-            if isinstance(hyperparams['opt_restarts'], int):
-                if hyperparams['opt_restarts'] < 1:
-                    raise ValueError("hyperparams['opt_restarts'] "
-                                     "must be positive")
-                else:
-                    self.restarts = hyperparams['opt_restarts']
-            else:
-                raise TypeError("hyperparams['opt_restarts'] "
-                                "must be an integer")
-        else:
-            self.restarts = self.n + 1
-        # Check that the contents of hyperparams are legal
-        if 'opt_budget' in hyperparams:
-            if isinstance(hyperparams['opt_budget'], int):
-                if hyperparams['opt_budget'] < 1:
-                    raise ValueError("hyperparams['opt_budget'] "
-                                     "must be positive")
-                else:
-                    self.budget = hyperparams['opt_budget']
-            else:
-                raise TypeError("hyperparams['opt_budget'] "
-                                "must be an integer")
-        else:
-            self.budget = 1000
-        # Check that the contents of hyperparams are legal
-        if 'opt_momentum' in hyperparams:
-            if isinstance(hyperparams['opt_momentum'], float):
-                if 0 <= hyperparams['opt_momentum'] < 1:
-                    self.momentum = hyperparams['opt_momentum']
-                else:
-                    raise ValueError("hyperparams['opt_momentum'] "
-                                     "must be in [0, 1)")
-            else:
-                raise TypeError("hyperparams['opt_momentum'] "
-                                "must be a float")
-        else:
-            self.momentum = 9e-1
         self.eps = np.sqrt(jnp.finfo(jnp.ones(1).dtype).eps)
-        if 'des_tols' in hyperparams:
-            if isinstance(hyperparams['des_tols'], np.ndarray):
-                if hyperparams['des_tols'].size != self.n:
-                    raise ValueError("the length of hyperparpams['des_tols']"
-                                     " must match the length of lb and ub")
-                if not np.all(hyperparams['des_tols']):
-                    raise ValueError("all entries in hyperparams['des_tols']"
-                                     " must be greater than 0")
-            else:
-                raise TypeError("hyperparams['des_tols'] must be an array.")
-            self.des_tols = np.asarray(hyperparams['des_tols'])
-        else:
-            self.des_tols = (np.ones(self.n) * self.eps)
-        # Check the hyperparameter dictionary for random generator
-        if 'np_random_gen' in hyperparams:
-            if isinstance(hyperparams['np_random_gen'], np.random.Generator):
-                self.np_rng = hyperparams['np_random_gen']
-            else:
-                raise TypeError("When present, hyperparams['np_random_gen'] "
-                                "must be an instance of the class "
-                                "numpy.random.Generator")
-        else:
-            self.np_rng = np.random.default_rng()
         self.acquisitions = []
         self.prev_centers = []
         self.targets = []
-        return
+        self.restarts = get_hp(
+            "opt_restarts", hyperparams, int, lambda x: x >= 1, self.n + 1
+        )
+        self.budget = get_hp(
+            "opt_budget", hyperparams, int, lambda x: x >= 1, 1000
+        )
+        self.momentum = get_hp(
+            "opt_momentum", hyperparams, float, lambda x: 0 <= x < 1, 9e-1
+        )
+        self.des_tols = get_hp(
+            "des_tols", hyperparams, np.ndarray,
+            lambda x: x.size == self.n and np.all(x > 0),
+            np.ones(self.n) * self.eps
+        )
+        self.np_rng = get_hp(
+            "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
+            np.random.default_rng()
+        )
 
     def _obj_func(self, x_in):
         """ A wrapper for the objective function and acquisition.
@@ -153,8 +107,9 @@ class LocalSurrogate_PS(SurrogateOptimizer):
         else:
             sdx_in = jnp.zeros(sx_in.size)
         fx_in = self.penalty_func(x_in, sx_in)
-        ax = self.acquisitions[self.q_ind].scalarize(fx_in, x_in,
-                                                     sx_in, sdx_in)
+        ax = self.acquisitions[self.q_ind].scalarize(
+                fx_in, x_in, sx_in, sdx_in
+        )
         return ax
 
     def _checkTR(self, center):
@@ -190,7 +145,6 @@ class LocalSurrogate_PS(SurrogateOptimizer):
                 self.prev_centers.append([ci, ri])
         # Reset the list of targets for next iteration
         self.targets = []
-        return
 
     def returnResults(self, x, fx, sx, sdx):
         """ Collect the results of a function evaluation.
@@ -213,7 +167,6 @@ class LocalSurrogate_PS(SurrogateOptimizer):
             # Remove any targets that have been "hit"
             if fxj < ti[2]:
                 del self.targets[i]
-        return
 
     def solve(self, x):
         """ Solve the surrogate problem in a trust region via pattern search.
@@ -232,8 +185,10 @@ class LocalSurrogate_PS(SurrogateOptimizer):
         if self.n != x.shape[1]:
             raise ValueError("The columns of x must match n")
         elif len(self.acquisitions) != x.shape[0]:
-            raise ValueError("The rows of x must match the number " +
-                             "of acquisition functions")
+            raise ValueError(
+                    "The rows of x must match the number of acquisition "
+                    "functions"
+            )
         # Initialize an empty list of results
         result = []
         lb_tmp = np.zeros(self.n)
@@ -256,14 +211,12 @@ class LocalSurrogate_PS(SurrogateOptimizer):
             except BaseException:
                 obj_func = self._obj_func
             # Get a candidate
-            xj, fj = _accelerated_pattern_search(self.n, lb_tmp,
-                                                 ub_tmp, x[j],
-                                                 obj_func,
-                                                 ibudget=self.budget,
-                                                 mesh_tol=mesh_tol,
-                                                 momentum=self.momentum,
-                                                 istarts=self.restarts,
-                                                 np_rng=self.np_rng)
+            xj, fj = _accelerated_pattern_search(
+                    self.n, lb_tmp, ub_tmp, x[j], obj_func,
+                    ibudget=self.budget, mesh_tol=mesh_tol,
+                    momentum=self.momentum, istarts=self.restarts,
+                    np_rng=self.np_rng
+            )
             result.append(xj)
             # We need to remember this "target" for later
             self.targets.append([x[j, :], rad, fj, j])
@@ -304,7 +257,6 @@ class LocalSurrogate_PS(SurrogateOptimizer):
         # Save file
         with open(filename, 'w') as fp:
             json.dump(ps_state, fp)
-        return
 
     def load(self, filename):
         """ Reload important data into this class after a previous save.
@@ -336,9 +288,9 @@ class LocalSurrogate_PS(SurrogateOptimizer):
             self.prev_centers.append([np.array(ci), np.array(ri)])
         self.targets = []
         for ti in ps_state['targets']:
-            self.targets.append([np.array(ti[0]), np.array(ti[1]),
-                                 ti[2], ti[3]])
-        return
+            self.targets.append([
+                    np.array(ti[0]), np.array(ti[1]), ti[2], ti[3]
+            ])
 
 
 class GlobalSurrogate_PS(SurrogateOptimizer):
@@ -381,66 +333,27 @@ class GlobalSurrogate_PS(SurrogateOptimizer):
 
         """
 
-        # Check inputs
         xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
         self.n = lb.size
         self.o = o
         self.lb = lb
         self.ub = ub
-        # Check that the contents of hyperparams are legal
-        if 'opt_budget' in hyperparams:
-            if isinstance(hyperparams['opt_budget'], int):
-                if hyperparams['opt_budget'] < 1:
-                    raise ValueError("hyperparams['opt_budget'] "
-                                     "must be positive")
-                else:
-                    self.opt_budget = hyperparams['opt_budget']
-            else:
-                raise TypeError("hyperparams['opt_budget'] "
-                                "must be an integer")
-        else:
-            self.opt_budget = 1500
-        # Check that the contents of hyperparams are legal
         self.eps = np.sqrt(jnp.finfo(jnp.ones(1).dtype).eps)
-        if 'gps_budget' in hyperparams:
-            if isinstance(hyperparams['gps_budget'], int):
-                if hyperparams['gps_budget'] < 1 or \
-                   hyperparams['gps_budget'] >= self.opt_budget:
-                    raise ValueError("hyperparams['gps_budget'] "
-                                     "must be between 1 and "
-                                     "hyperparams['opt_budget']")
-                else:
-                    self.gps_budget = hyperparams['gps_budget']
-            else:
-                raise TypeError("hyperparams['opt_budget'] "
-                                "must be an integer")
-        else:
-            self.gps_budget = int(2 * self.opt_budget / 3)
-        # Check that the contents of hyperparams are legal
-        if 'opt_momentum' in hyperparams:
-            if isinstance(hyperparams['opt_momentum'], float):
-                if 0 <= hyperparams['opt_momentum'] < 1:
-                    self.momentum = hyperparams['opt_momentum']
-                else:
-                    raise ValueError("hyperparams['opt_momentum'] "
-                                     "must be in [0, 1)")
-            else:
-                raise TypeError("hyperparams['opt_momentum'] "
-                                "must be a float")
-        else:
-            self.momentum = 9e-1
-        # Check the hyperparameter dictionary for random generator
-        if 'np_random_gen' in hyperparams:
-            if isinstance(hyperparams['np_random_gen'], np.random.Generator):
-                self.np_rng = hyperparams['np_random_gen']
-            else:
-                raise TypeError("When present, hyperparams['np_random_gen'] "
-                                "must be an instance of the class "
-                                "numpy.random.Generator")
-        else:
-            self.np_rng = np.random.default_rng()
         self.acquisitions = []
-        return
+        self.opt_budget = get_hp(
+            "opt_budget", hyperparams, int, lambda x: x >= 1, 1500
+        )
+        self.gps_budget = get_hp(
+            "gps_budget", hyperparams, int,
+            lambda x: 1 <= x <= self.opt_budget, int(2 * self.opt_budget / 3)
+        )
+        self.momentum = get_hp(
+            "opt_momentum", hyperparams, float, lambda x: 0 <= x < 1, 9e-1
+        )
+        self.np_rng = get_hp(
+            "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
+            np.random.default_rng()
+        )
 
     def _obj_func(self, x_in):
         """ A wrapper for the objective function and acquisition.
@@ -482,8 +395,10 @@ class GlobalSurrogate_PS(SurrogateOptimizer):
         if self.n != x.shape[1]:
             raise ValueError("The columns of x must match n")
         elif len(self.acquisitions) != x.shape[0]:
-            raise ValueError("The rows of x must match the number " +
-                             "of acquisition functions")
+            raise ValueError(
+                    "The rows of x must match the number of acquisition "
+                    "functions"
+            )
         # Create an infinite trust region
         rad = np.ones(self.n) * np.inf
         self.setTR(self.lb, rad)
@@ -543,14 +458,11 @@ class GlobalSurrogate_PS(SurrogateOptimizer):
             except BaseException:
                 obj_func = self._obj_func
             # Get a candidate
-            xj, fj = _accelerated_pattern_search(self.n, self.lb,
-                                                 self.ub, x0,
-                                                 obj_func,
-                                                 ibudget=self.gps_budget,
-                                                 mesh_start=0.1,
-                                                 mesh_tol=mesh_tol,
-                                                 momentum=self.momentum,
-                                                 istarts=1)
+            xj, fj = _accelerated_pattern_search(
+                    self.n, self.lb, self.ub, x0, obj_func,
+                    ibudget=self.gps_budget, mesh_start=0.1, mesh_tol=mesh_tol,
+                    momentum=self.momentum, istarts=1
+            )
             result.append(xj)
         self.objectives = None
         self.constraints = None

--- a/parmoo/optimizers/random_search.py
+++ b/parmoo/optimizers/random_search.py
@@ -16,7 +16,7 @@ import jax
 from jax import numpy as jnp
 import numpy as np
 from parmoo.optimizers.surrogate_optimizer import SurrogateOptimizer
-from parmoo.utilities.error_checks import xerror
+from parmoo.utilities.error_checks import get_hp, xerror
 
 
 class GlobalSurrogate_RS(SurrogateOptimizer):
@@ -54,38 +54,19 @@ class GlobalSurrogate_RS(SurrogateOptimizer):
 
         """
 
-        # Check inputs
         xerror(o=o, lb=lb, ub=ub, hyperparams=hyperparams)
         self.o = o
         self.n = lb.size
         self.lb = lb
         self.ub = ub
-        # Check that the contents of hyperparams is legal
-        if 'opt_budget' in hyperparams:
-            if isinstance(hyperparams['opt_budget'], int):
-                if hyperparams['opt_budget'] < 1:
-                    raise ValueError("hyperparams['opt_budget'] "
-                                     "must be positive")
-                else:
-                    self.budget = hyperparams['opt_budget']
-            else:
-                raise TypeError("hyperparams['opt_budget'] "
-                                "must be an integer")
-        else:
-            self.budget = 10000
-        # Check the hyperparameter dictionary for random generator
-        if 'np_random_gen' in hyperparams:
-            if isinstance(hyperparams['np_random_gen'], np.random.Generator):
-                self.np_rng = hyperparams['np_random_gen']
-            else:
-                raise TypeError("When present, hyperparams['np_random_gen'] "
-                                "must be an instance of the class "
-                                "numpy.random.Generator")
-        else:
-            self.np_rng = np.random.default_rng()
-        # Initialize the list of acquisition functions
         self.acquisitions = []
-        return
+        self.budget = get_hp(
+            "opt_budget", hyperparams, int, lambda x: x >= 1, 10000
+        )
+        self.np_rng = get_hp(
+            "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
+            np.random.default_rng()
+        )
 
     def solve(self, x):
         """ Solve the surrogate problem using random search.
@@ -106,8 +87,10 @@ class GlobalSurrogate_RS(SurrogateOptimizer):
         if self.n != x.shape[1]:
             raise ValueError("The columns of x must match n")
         elif len(self.acquisitions) != x.shape[0]:
-            raise ValueError("The rows of x must match the number " +
-                             "of acquisition functions")
+            raise ValueError(
+                    "The rows of x must match the number of acquisition "
+                    "functions"
+            )
         # Initialize the surrogates with an infinite trust region
         rad = np.ones(self.n) * np.inf
         self.setTR(x[0, :], rad)

--- a/parmoo/searches/latin_hypercube.py
+++ b/parmoo/searches/latin_hypercube.py
@@ -11,7 +11,7 @@ The classes include:
 
 import numpy as np
 from parmoo.searches.global_search import GlobalSearch
-from parmoo.utilities.error_checks import xerror
+from parmoo.utilities.error_checks import get_hp, xerror
 from scipy.stats import qmc
 
 
@@ -48,37 +48,18 @@ class LatinHypercube(GlobalSearch):
 
         """
 
-        # Check inputs
         xerror(o=m, lb=lb, ub=ub, hyperparams=hyperparams)
         self.n = lb.size
-        # Assign the bounds
         self.lb = lb
         self.ub = ub
-        # Check for a search budget
-        if 'search_budget' in hyperparams:
-            if isinstance(hyperparams['search_budget'], int):
-                if hyperparams['search_budget'] < 0:
-                    raise ValueError("hyperparams['search_budget'] must "
-                                     "be nonnegative")
-                else:
-                    self.budget = hyperparams['search_budget']
-            else:
-                raise ValueError("hyperparams['search_budget'] must "
-                                 "be an int")
-        else:
-            self.budget = 100
-        # Check the hyperparameter dictionary for random generator
-        if 'np_random_gen' in hyperparams:
-            if isinstance(hyperparams['np_random_gen'], np.random.Generator):
-                self.np_rng = hyperparams['np_random_gen']
-            else:
-                raise TypeError("When present, hyperparams['np_random_gen'] "
-                                "must be an instance of the class "
-                                "numpy.random.Generator")
-        else:
-            self.np_rng = np.random.default_rng()
+        self.budget = get_hp(
+                "search_budget", hyperparams, int, lambda x: x >= 0, 100
+        )
+        self.np_rng = get_hp(
+                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
+                np.random.default_rng()
+        )
         self.sampler = qmc.LatinHypercube(d=self.n, seed=self.np_rng)
-        return
 
     def startSearch(self, lb, ub):
         """ Begin a new Latin hypercube sampling.

--- a/parmoo/searches/latin_hypercube.py
+++ b/parmoo/searches/latin_hypercube.py
@@ -56,8 +56,8 @@ class LatinHypercube(GlobalSearch):
                 "search_budget", hyperparams, int, lambda x: x >= 0, 100
         )
         self.np_rng = get_hp(
-                "np_random_gen", hyperparams, np.random.Generator, lambda x: True,
-                np.random.default_rng()
+                "np_random_gen", hyperparams, np.random.Generator,
+                lambda x: True, np.random.default_rng()
         )
         self.sampler = qmc.LatinHypercube(d=self.n, seed=self.np_rng)
 

--- a/parmoo/surrogates/gaussian_proc.py
+++ b/parmoo/surrogates/gaussian_proc.py
@@ -14,7 +14,7 @@ from jax import numpy as jnp
 from jax import lax
 import numpy as np
 from parmoo.surrogates.surrogate_function import SurrogateFunction
-from parmoo.utilities.error_checks import xerror
+from parmoo.utilities.error_checks import get_hp, xerror
 from scipy.stats import tstd
 
 
@@ -58,70 +58,33 @@ class GaussRBF(SurrogateFunction):
 
         """
 
-        # Check inputs
         xerror(o=m, lb=lb, ub=ub, hyperparams=hyperparams)
-        # Initialize problem dimensions
         self.m = m
         self.lb = lb
         self.ub = ub
         self.n = self.lb.size
         self.x_std_dev = 0.0
-        # Create empty database
         self.x_vals = np.zeros((0, self.n))
         self.f_vals = np.zeros((0, self.m))
         self.weights = np.zeros((0, 0))
         self.prior = np.zeros((self.n+1, self.m))
         self.v = np.zeros((0, 0))
         self.w = np.zeros((0, 0))
+        self.mu = np.sqrt(jnp.finfo(jnp.ones(1).dtype).eps)
         self.y_std_dev = np.ones(self.m)
-        # Initialize trust-region settings
         self.tr_center = np.zeros(0)
         self.loc_inds = []
-        # Check for the 'nugget' optional value in hyperparams
-        if 'nugget' in hyperparams:
-            if isinstance(hyperparams['nugget'], float):
-                self.nugget = hyperparams['nugget']
-                if self.nugget < 0.0:
-                    raise ValueError("hyperparams['nugget'] cannot be a"
-                                     + " negative number")
-            else:
-                raise ValueError("hyperparams['nugget'] contained an illegal"
-                                 + " value")
-        else:
-            self.nugget = 0.0
-        # Check for 'des_tols' optional key in hyperparams
-        self.mu = np.sqrt(jnp.finfo(jnp.ones(1).dtype).eps)
-        if 'des_tols' in hyperparams:
-            if isinstance(hyperparams['des_tols'], np.ndarray):
-                if hyperparams['des_tols'].size == self.n:
-                    if np.all(hyperparams['des_tols'] > 0.0):
-                        self.eps = hyperparams['des_tols']
-                    else:
-                        raise ValueError("hyperparams['des_tols'] must all be"
-                                         + " greater than 0")
-                else:
-                    raise ValueError("hyperparams['des_tols'] must have length"
-                                     + " n")
-            else:
-                raise ValueError("hyperparams['des_tols'] contained an illegal"
-                                 + " value")
-        else:
-            self.eps = np.zeros(self.n)
-            self.eps[:] = self.mu
-        # Check for 'tail_order' optional key in hyperparams
-        if 'tail_order' in hyperparams:
-            if isinstance(hyperparams['tail_order'], int):
-                if hyperparams['tail_order'] in [0, 1]:
-                    self.order = hyperparams['tail_order']
-                else:
-                    raise ValueError("hyperparams['tail_order'] must be "
-                                     + "0 or 1")
-            else:
-                raise ValueError("hyperparams['tail_order'] contained an "
-                                 + "illegal value")
-        else:
-            self.order = 0
-        return
+        self.nugget = get_hp(
+                "nugget", hyperparams, float, lambda x: x >= 0, 0.0
+        )
+        self.eps = get_hp(
+                "des_tols", hyperparams, np.ndarray,
+                lambda x: x.size == self.n and np.all(x > 0),
+                np.ones(self.n) * self.mu
+        )
+        self.order = get_hp(
+                "tail_order", hyperparams, int, lambda x: x in [0, 1], 0
+        )
 
     def fit(self, x, f):
         """ Fit a new Gaussian RBF to the given data.

--- a/parmoo/surrogates/polynomial.py
+++ b/parmoo/surrogates/polynomial.py
@@ -12,7 +12,7 @@ The classes include:
 from jax import numpy as jnp
 import numpy as np
 from parmoo.surrogates.surrogate_function import SurrogateFunction
-from parmoo.utilities.error_checks import xerror
+from parmoo.utilities.error_checks import get_hp, xerror
 
 
 class Linear(SurrogateFunction):
@@ -52,40 +52,22 @@ class Linear(SurrogateFunction):
 
         """
 
-        # Check inputs
         xerror(o=m, lb=lb, ub=ub, hyperparams=hyperparams)
-        # Initialize problem dimensions
         self.m = m
         self.lb = lb
         self.ub = ub
         self.n = self.lb.size
-        # Create empty database
         self.x_vals = np.zeros((0, self.n))
         self.f_vals = np.zeros((0, self.m))
         self.weights = np.zeros(self.n + 1)
-        # Initialize trust-region settings
         self.tr_center = np.zeros(0)
         self.loc_inds = []
-        # Check for 'des_tols' optional key in hyperparams
         mu = np.sqrt(jnp.finfo(jnp.ones(1).dtype).eps)
-        if 'des_tols' in hyperparams:
-            if isinstance(hyperparams['des_tols'], np.ndarray):
-                if hyperparams['des_tols'].size == self.n:
-                    if np.all(hyperparams['des_tols'] > 0.0):
-                        self.eps = hyperparams['des_tols']
-                    else:
-                        raise ValueError("hyperparams['des_tols'] must all be"
-                                         + " greater than 0")
-                else:
-                    raise ValueError("hyperparams['des_tols'] must have length"
-                                     + " n")
-            else:
-                raise ValueError("hyperparams['des_tols'] contained an illegal"
-                                 + " value")
-        else:
-            self.eps = np.zeros(self.n)
-            self.eps[:] = mu
-        return
+        self.eps = get_hp(
+                "des_tols", hyperparams, np.ndarray,
+                lambda x: x.size == self.n and np.all(x > 0),
+                np.ones(self.n) * mu
+        )
 
     def fit(self, x, f):
         """ Fit a new linear model to the given data.

--- a/parmoo/tests/unit_tests/test_gaussian_proc.py
+++ b/parmoo/tests/unit_tests/test_gaussian_proc.py
@@ -18,7 +18,7 @@ def test_GaussRBF():
     import pytest
 
     # Try some bad initializations to test error handling
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         GaussRBF(2, np.zeros(3), np.ones(3), {'nugget': []})
     with pytest.raises(ValueError):
         GaussRBF(2, np.zeros(3), np.ones(3), {'nugget': -1.0})
@@ -28,7 +28,7 @@ def test_GaussRBF():
     with pytest.raises(ValueError):
         GaussRBF(2, np.zeros(3), np.ones(3),
                  {'nugget': 0.1, 'des_tols': np.zeros(2)})
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         GaussRBF(2, np.zeros(3), np.ones(3),
                  {'nugget': 0.1, 'des_tols': 0.1})
     # Create 2 identical RBFs
@@ -215,7 +215,7 @@ def test_LocalGaussRBF():
     import pytest
 
     # Try some bad initializations to test error handling
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         GaussRBF(2, np.zeros(3), np.ones(3), {'nugget': []})
     with pytest.raises(ValueError):
         GaussRBF(2, np.zeros(3), np.ones(3), {'nugget': -1.0})
@@ -225,7 +225,7 @@ def test_LocalGaussRBF():
     with pytest.raises(ValueError):
         GaussRBF(2, np.zeros(3), np.ones(3),
                  {'nugget': 0.1, 'des_tols': np.zeros(2)})
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         GaussRBF(2, np.zeros(3), np.ones(3), {'nugget': 0.1, 'des_tols': 0.1})
     # Create 2 identical RBFs
     rbf1 = GaussRBF(2, np.zeros(3), np.ones(3), {'tail_order': 1})

--- a/parmoo/tests/unit_tests/test_latin_hypercube.py
+++ b/parmoo/tests/unit_tests/test_latin_hypercube.py
@@ -16,7 +16,7 @@ def test_LatinHypercube():
     lb = -1.0 * np.ones(5)
     ub = np.zeros(5)
     # Try to initialize a bad search to test error handling
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         LatinHypercube(2, lb, ub, {'search_budget': 2.0})
     with pytest.raises(ValueError):
         LatinHypercube(2, lb, ub, {'search_budget': -1})

--- a/parmoo/tests/unit_tests/test_moop_utils.py
+++ b/parmoo/tests/unit_tests/test_moop_utils.py
@@ -49,7 +49,7 @@ def test_check_sims():
     with pytest.raises(TypeError):
         check_sims(3, 5.0)
     simdict = {}
-    with pytest.raises(AttributeError):
+    with pytest.raises(KeyError):
         check_sims(3, simdict)
     simdict['m'] = 1.0
     with pytest.raises(TypeError):
@@ -58,7 +58,7 @@ def test_check_sims():
     with pytest.raises(ValueError):
         check_sims(3, simdict)
     simdict['m'] = 1
-    with pytest.raises(AttributeError):
+    with pytest.raises(KeyError):
         check_sims(3, simdict)
     simdict['search'] = LatinHypercube(1, np.zeros(3), np.ones(3), {})
     with pytest.raises(TypeError):
@@ -67,7 +67,7 @@ def test_check_sims():
     with pytest.raises(TypeError):
         check_sims(3, simdict)
     simdict['search'] = LatinHypercube
-    with pytest.raises(AttributeError):
+    with pytest.raises(KeyError):
         check_sims(3, simdict)
     simdict['surrogate'] = GaussRBF(1, np.zeros(1), np.ones(1), {})
     with pytest.raises(TypeError):
@@ -76,7 +76,7 @@ def test_check_sims():
     with pytest.raises(TypeError):
         check_sims(3, simdict)
     simdict['surrogate'] = GaussRBF
-    with pytest.raises(AttributeError):
+    with pytest.raises(KeyError):
         check_sims(3, simdict)
     simdict['sim_func'] = {}
     with pytest.raises(TypeError):
@@ -93,7 +93,7 @@ def test_check_sims():
     with pytest.raises(TypeError):
         check_sims(3, simdict)
     simdict['sim_db'] = {'x_vals': []}
-    with pytest.raises(AttributeError):
+    with pytest.raises(KeyError):
         check_sims(3, simdict)
     simdict['sim_db'] = {'x_vals': "hel", 's_vals': "lo"}
     with pytest.raises(TypeError):

--- a/parmoo/tests/unit_tests/test_polynomial.py
+++ b/parmoo/tests/unit_tests/test_polynomial.py
@@ -21,7 +21,7 @@ def test_Linear():
         Linear(2, np.zeros(3), np.ones(3), {'des_tols': np.zeros(3)})
     with pytest.raises(ValueError):
         Linear(2, np.zeros(3), np.ones(3), {'des_tols': np.zeros(2)})
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         Linear(2, np.zeros(3), np.ones(3), {'des_tols': 0.1})
     # Create 2 identical Linear models
     lsm1 = Linear(2, np.zeros(3), np.ones(3), {})

--- a/parmoo/utilities/error_checks.py
+++ b/parmoo/utilities/error_checks.py
@@ -105,11 +105,10 @@ def xerror(o=1, lb=None, ub=None, hyperparams=None):
     if hyperparams is None:
         hyperparams = {}
     # Check the objective count
-    if isinstance(o, int):
-        if o < 1:
-            raise ValueError("o must be positive")
-    else:
+    if not isinstance(o, int):
         raise TypeError("o must be an integer")
+    if o < 1:
+        raise ValueError("o must be positive")
     # Check that the bounds are legal
     if not isinstance(lb, np.ndarray):
         raise TypeError("lb must be a numpy array")

--- a/parmoo/utilities/error_checks.py
+++ b/parmoo/utilities/error_checks.py
@@ -1,13 +1,83 @@
 """ This module contains several auxiliary functions to aide in error handling.
 
 These functions may also be of external interest. They are:
- * `xerror(o, lb, ub, hyperparams)`
  * `check_names(name, des_schema, sim_schema, obj_schema, con_schema)`
  * `gradient_error(arg1, arg2)`
+ * `get_hp(key, hyperparams, expected_type, is_legal, default_value)`
+ * `xerror(o, lb, ub, hyperparams)`
 
 """
 
 import numpy as np
+
+
+def check_names(name, *args):
+    """ Typecheck the input arguments for a new variable name.
+
+    Args:
+        name (str): A str that could be used as the variable name.
+
+        *args (list of tuples): 1 or more lists of existing variable names to
+            check against in order to guarantee that name is unique.
+
+    """
+
+    if not isinstance(name, str):
+        raise TypeError("Every variable name must be a string type")
+    for arg in args:
+        if any([name == ni[0] for ni in arg]):
+            raise ValueError(f"The variable name {name} is already in use")
+
+
+def gradient_error(arg1, arg2):
+    """ Raises an error, warning users that the gradient is undefined.
+
+    Args:
+        arg1 (un-used): Here to match the interface of a gradient or bwd pass
+            function.
+        arg2 (un-used): Here to match the interface of a gradient or bwd pass
+            function.
+
+    """
+
+    raise ValueError("1 or more grad func is undefined")
+
+
+def get_hp(key, hyperparams, expected_type, is_legal, default_value):
+    """ Search for key in the hyperparams dictionary.
+
+    Args:
+        key (hashable): The key to search for
+        hyperparams (dict): The hyperparameters dictionary to search
+        expected_type (type): The expected type for hyperparams[key]
+        is_legal (callable): A callable object to check the legalality
+            of hyperparams[key]. Returns True if and only if hyperparams[key]
+            contains a legal value
+        default_value (any): The default value to assign when key is not in
+            hyperparams. When the value is None, key is required in
+            hyperparams.
+
+    """
+
+    if not isinstance(hyperparams, dict):
+        raise TypeError("hyperparams must be a Python dict type")
+    if key not in hyperparams and default_value is None:
+        raise KeyError(
+            f"'{key}' is a required key in hyperparams for one or more of "
+            "the methods used"
+        )
+    elif key not in hyperparams:
+        return default_value
+    if not isinstance(hyperparams[key], expected_type):
+        raise TypeError(
+            f"hyperparams[{key}] must be an instance of "
+            f"{expected_type.__name__}"
+        )
+    if not is_legal(hyperparams[key]):
+        raise ValueError(
+            f"hyperparams[{key}] contains an illegal value"
+        )
+    return hyperparams[key]
 
 
 def xerror(o=1, lb=None, ub=None, hyperparams=None):
@@ -52,35 +122,3 @@ def xerror(o=1, lb=None, ub=None, hyperparams=None):
     # Check the hyperparams dict
     if not isinstance(hyperparams, dict):
         raise TypeError("hyperparams must be a dictionary")
-
-
-def check_names(name, *args):
-    """ Typecheck the input arguments for a new variable name.
-
-    Args:
-        name (str): A str that could be used as the variable name.
-
-        *args (list of tuples): 1 or more lists of existing variable names to
-            check against in order to guarantee that name is unique.
-
-    """
-
-    if not isinstance(name, str):
-        raise TypeError("Every variable name must be a string type")
-    for arg in args:
-        if any([name == ni[0] for ni in arg]):
-            raise ValueError(f"The variable name {name} is already in use")
-
-
-def gradient_error(arg1, arg2):
-    """ Raises an error, warning users that the gradient is undefined.
-
-    Args:
-        arg1 (un-used): Here to match the interface of a gradient or bwd pass
-            function.
-        arg2 (un-used): Here to match the interface of a gradient or bwd pass
-            function.
-
-    """
-
-    raise ValueError("1 or more grad func is undefined")

--- a/parmoo/utilities/error_checks.py
+++ b/parmoo/utilities/error_checks.py
@@ -47,12 +47,12 @@ def get_hp(key, hyperparams, expected_type, is_legal, default_value):
     """ Search for key in the hyperparams dictionary.
 
     Args:
-        key (hashable): The key to search for
-        hyperparams (dict): The hyperparameters dictionary to search
+        key (hashable): The key to search in the hyperparams dictionary.
+        hyperparams (dict): The hyperparameters dictionary to search.
         expected_type (type): The expected type for hyperparams[key]
-        is_legal (callable): A callable object to check the legalality
-            of hyperparams[key]. Returns True if and only if hyperparams[key]
-            contains a legal value
+        is_legal (callable): A callable object to check the legality of
+            hyperparams[key]. Returns True if and only if hyperparams[key]
+            contains a legal value.
         default_value (any): The default value to assign when key is not in
             hyperparams. When the value is None, key is required in
             hyperparams.

--- a/parmoo/utilities/moop_utils.py
+++ b/parmoo/utilities/moop_utils.py
@@ -6,6 +6,7 @@ These functions may also be of external interest. They are:
  * `to_array(x, dtype)`
  * `from_array(x, dtype)`
  * `approx_equal(x1, x2, des_tols)`
+ * `get_hp(key, hyperparams, expected_type, is_legal, default_value)`
 
 """
 
@@ -205,3 +206,41 @@ def approx_equal(x1, x2, des_tols):
         ):
             return False
     return True
+
+
+def get_hp(key, hyperparams, expected_type, is_legal, default_value):
+    """ Search for key in the hyperparams dictionary.
+
+    Args:
+        key (hashable): The key to search for
+        hyperparams (dict): The hyperparameters dictionary to search
+        expected_type (type): The expected type for hyperparams[key]
+        is_legal (callable): A callable object to check the legalality
+            of hyperparams[key]. Returns True if and only if hyperparams[key]
+            contains a legal value
+        default_value (any): The default value to assign when key is not in
+            hyperparams. When the value is None, key is required in
+            hyperparams.
+
+    """
+
+    if key in hyperparams:
+        if isinstance(hyperparams[key], expected_type):
+            if is_legal(hyperparams[key]):
+                return hyperparams[key]
+            else:
+                raise ValueError(
+                    f"hyperparams[{key}] contains an illegal value"
+                )
+        else:
+            raise TypeError(
+                f"hyperparams[{key}] must be an instance of "
+                f"{expected_type.__name__}"
+            )
+    else:
+        if default_value is None:
+            raise KeyError(
+                f"'{key}' is a required key in hyperparams for one or more "
+                "of the methods used"
+            )
+        return default_value

--- a/parmoo/utilities/moop_utils.py
+++ b/parmoo/utilities/moop_utils.py
@@ -6,7 +6,6 @@ These functions may also be of external interest. They are:
  * `to_array(x, dtype)`
  * `from_array(x, dtype)`
  * `approx_equal(x1, x2, des_tols)`
- * `get_hp(key, hyperparams, expected_type, is_legal, default_value)`
 
 """
 
@@ -206,41 +205,3 @@ def approx_equal(x1, x2, des_tols):
         ):
             return False
     return True
-
-
-def get_hp(key, hyperparams, expected_type, is_legal, default_value):
-    """ Search for key in the hyperparams dictionary.
-
-    Args:
-        key (hashable): The key to search for
-        hyperparams (dict): The hyperparameters dictionary to search
-        expected_type (type): The expected type for hyperparams[key]
-        is_legal (callable): A callable object to check the legalality
-            of hyperparams[key]. Returns True if and only if hyperparams[key]
-            contains a legal value
-        default_value (any): The default value to assign when key is not in
-            hyperparams. When the value is None, key is required in
-            hyperparams.
-
-    """
-
-    if key in hyperparams:
-        if isinstance(hyperparams[key], expected_type):
-            if is_legal(hyperparams[key]):
-                return hyperparams[key]
-            else:
-                raise ValueError(
-                    f"hyperparams[{key}] contains an illegal value"
-                )
-        else:
-            raise TypeError(
-                f"hyperparams[{key}] must be an instance of "
-                f"{expected_type.__name__}"
-            )
-    else:
-        if default_value is None:
-            raise KeyError(
-                f"'{key}' is a required key in hyperparams for one or more "
-                "of the methods used"
-            )
-        return default_value


### PR DESCRIPTION
No significant changes but massively reduce the lines of code.

I think the error checking in parmoo is excessively complex and takes away from the readability of the algorithms.

I started by adding just 2 utilities to check some of the common patterns I use to validate inputs, and use them to replace all the checks for the optional hyperparameters.

In a few places I also flattened nested checks to avoid excess branching logic, which is harder to write tests for.

Starting a new thing where we update the CHANGELOG in each PR, in order to avoid having to go back and summarize all the changes when we do a release.

No changes to the unit tests yet, but this is in preparation to re-write the unit tests to be a bit more maintainable and less brittle.